### PR TITLE
Add a metric of AppWrappers counts per phase, step and priority

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
+	github.com/prometheus/client_golang v1.16.0
 	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
@@ -42,7 +43,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 IBM Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	mcadv1beta1 "github.com/project-codeflare/mcad/api/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type phaseStepPriority struct {
+	phase    mcadv1beta1.AppWrapperPhase
+	step     mcadv1beta1.AppWrapperStep
+	priority int
+}
+
+var (
+	appWrappersCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "appwrappers_count",
+		Help:      "AppWrappers count per phase, step and priority",
+	}, []string{"phase", "step", "priority"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		appWrappersCount,
+	)
+}


### PR DESCRIPTION
This PR adds a custom metric to expose how many AppWrappers are per phase, step and priority.


This can be tested by running MCAD, creating a few AppWrappers and then querying the `metrics` endpoint:
```
curl localhost:8080/metrics | grep appwrappers_count


# HELP mcad_appwrappers_count AppWrappers count per state
# TYPE mcad_appwrappers_count gauge
mcad_appwrappers_count{phase="Completed",priority="0",step=""} 1
mcad_appwrappers_count{phase="Running",priority="0",step="created"} 1
```
