### PR TITLE
Add resource capacity metrics per node

### DIFF
--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -90,11 +90,13 @@ func updateMetrics(capacity Weights, node v1.Node) {
 		totalCapacityMemory.WithLabelValues(node.Name).Set(capacityMemory)
 	}
 
-	capacityGpu, err := Dec2float64(capacity["nvidia.com/gpu"])
-	if err != nil {
-		mcadLog.Error(err, "Unable to get gpu capacity", "node", node.Name)
-	} else {
-		totalCapacityGpu.WithLabelValues(node.Name).Set(capacityGpu)
+	if val, exists := capacity["nvidia.com/gpu"]; exists {
+		capacityGpu, err := Dec2float64(val)
+		if err != nil {
+			mcadLog.Error(err, "Unable to get GPU capacity", "node", node.Name)
+		} else {
+			totalCapacityGpu.WithLabelValues(node.Name).Set(capacityGpu)
+		}
 	}
 }
 

--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -79,21 +79,21 @@ func updateMetrics(capacity Weights, node v1.Node) {
 	// https://github.com/go-inf/inf/issues/7#issuecomment-504729949
 	capacityCpu, err := strconv.ParseFloat(capacity["cpu"].String(), 64)
 	if err != nil {
-		mcadLog.V(1).Error(err, "Unable to get CPU capacity", "node", node.Name)
+		mcadLog.Error(err, "Unable to get CPU capacity", "node", node.Name)
 	} else {
 		totalCapacityCpu.WithLabelValues(node.Name).Set(capacityCpu)
 	}
 
 	capacityMemory, err := strconv.ParseFloat(capacity["memory"].String(), 64)
 	if err != nil {
-		mcadLog.V(1).Error(err, "Unable to get memory capacity", "node", node.Name)
+		mcadLog.Error(err, "Unable to get memory capacity", "node", node.Name)
 	} else {
 		totalCapacityMemory.WithLabelValues(node.Name).Set(capacityMemory)
 	}
 
 	capacityGpu, err := strconv.ParseFloat(capacity["nvidia.com/gpu"].String(), 64)
 	if err != nil {
-		mcadLog.V(1).Error(err, "Unable to get gpu capacity", "node", node.Name)
+		mcadLog.Error(err, "Unable to get gpu capacity", "node", node.Name)
 	} else {
 		totalCapacityGpu.WithLabelValues(node.Name).Set(capacityGpu)
 	}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -34,10 +34,28 @@ var (
 		Name:      "appwrappers_count",
 		Help:      "AppWrappers count per phase, step and priority",
 	}, []string{"phase", "step", "priority"})
+	totalCapacityCpu = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "capacity_cpu",
+		Help:      "Available CPU capacity per node, excluding non-AppWrapper pods",
+	}, []string{"node"})
+	totalCapacityMemory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "capacity_memory",
+		Help:      "Available memory capacity per node, excluding non-AppWrapper pods",
+	}, []string{"node"})
+	totalCapacityGpu = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "capacity_gpu",
+		Help:      "Available gpu capacity per node, excluding non-AppWrapper pods",
+	}, []string{"node"})
 )
 
 func init() {
 	metrics.Registry.MustRegister(
 		appWrappersCount,
+		totalCapacityCpu,
+		totalCapacityMemory,
+		totalCapacityGpu,
 	)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -47,7 +47,7 @@ var (
 	totalCapacityGpu = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "mcad",
 		Name:      "capacity_gpu",
-		Help:      "Available gpu capacity per node, excluding non-AppWrapper pods",
+		Help:      "Available GPU capacity per node, excluding non-AppWrapper pods",
 	}, []string{"node"})
 )
 


### PR DESCRIPTION
This PR adds resource capacity metrics per node (CPU, memory and GPU)



## Example Output:
```
curl -s localhost:8080/metrics | grep capacity


# HELP mcad_capacity_cpu Available CPU capacity per node, excluding non-AppWrapper pods
# TYPE mcad_capacity_cpu gauge
mcad_capacity_cpu{node="ip-10-0-138-218.ec2.internal"} 13.401
mcad_capacity_cpu{node="ip-10-0-144-225.ec2.internal"} 26.827
mcad_capacity_cpu{node="ip-10-0-163-118.ec2.internal"} 40.228
# HELP mcad_capacity_memory Available memory capacity per node, excluding non-AppWrapper pods
# TYPE mcad_capacity_memory gauge
mcad_capacity_memory{node="ip-10-0-138-218.ec2.internal"} 5.9566645248e+10
mcad_capacity_memory{node="ip-10-0-144-225.ec2.internal"} 1.20639045632e+11
mcad_capacity_memory{node="ip-10-0-163-118.ec2.internal"} 1.79178094592e+11
```