### PR TITLE
Add requested resources metrics per priority

### DIFF
--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -49,6 +49,22 @@ var (
 		Name:      "capacity_gpu",
 		Help:      "Available GPU capacity per node, excluding non-AppWrapper pods",
 	}, []string{"node"})
+
+	requestedCpu = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "requested_cpu",
+		Help:      "Requested CPU per priority",
+	}, []string{"priority"})
+	requestedMemory = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "requested_memory",
+		Help:      "Requested memory per priority",
+	}, []string{"priority"})
+	requestedGpu = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "mcad",
+		Name:      "requested_gpu",
+		Help:      "Requested GPU per priority",
+	}, []string{"priority"})
 )
 
 func init() {
@@ -57,5 +73,8 @@ func init() {
 		totalCapacityCpu,
 		totalCapacityMemory,
 		totalCapacityGpu,
+		requestedCpu,
+		requestedMemory,
+		requestedGpu,
 	)
 }


### PR DESCRIPTION

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This PR adds custom metrics (Prometheus Gauges) for the current consumed resources (CPU/memory/GPU) per priority.

I preferred measuring the consumed resources, rather than the available capacity as logged [here](https://github.com/project-codeflare/mcad/blob/658a2b6bb050218bd58b345a44a8712aaed33eae/internal/controller/dispatch_logic.go#L152C1-L152C3) because summarizing over the consumed resources in PromQL has meaning while summarizing over the available capacity doesn't.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

I created 3 AppWrappers with 2 different priorities and requested resources as follows:
```
  ...
  priority: 1
  ...
      custompodresources:
      - replicas: 1
        requests:
          cpu: 100m
          memory: 128M
---
  ...
  priority: 3
  ...
      custompodresources:
      - replicas: 2
        requests:
          cpu: 200m
          memory: 256M
---
  ...
  priority: 3
  ...
      custompodresources:
      - replicas: 1
        requests:
          cpu: 300m
          memory: 512M
          nvidia.com/gpu: 0
```

While running MCAD, the new metrics are:
```
curl -s localhost:8080/metrics | grep mcad_requested

# HELP mcad_requested_cpu Requested CPU per priority
# TYPE mcad_requested_cpu gauge
mcad_requested_cpu{priority="1"} 0.1
mcad_requested_cpu{priority="3"} 0.7
# HELP mcad_requested_gpu Requested GPU per priority
# TYPE mcad_requested_gpu gauge
mcad_requested_gpu{priority="3"} 0
# HELP mcad_requested_memory Requested memory per priority
# TYPE mcad_requested_memory gauge
mcad_requested_memory{priority="1"} 1.28e+08
mcad_requested_memory{priority="3"} 1.024e+09
```



## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->