### PR TITLE
Trigger dispatch on startup

### DIFF
--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -214,6 +214,8 @@ func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return err
 	}
+	// initialize periodic dispatch invocation
+	r.triggerDispatch()
 	// watch AppWrapper pods, jobs, watch events
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcadv1beta1.AppWrapper{}).


### PR DESCRIPTION
The `dispatch` method always requeues itself ensuring it is called at least every `dispatchDelay`. This PR ensure `dispatch` is queued on startup rather than waiting for a first AppWrapper to change state (queued, deleted, or completed).

This PR therefore ensures logs and metrics generated during `dispatch` will exist and be periodically updated even if, for example, there are no AppWrappers in the cluster.