### PR TITLE
Restore EmbeddedResource annotation on generic items

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -171,6 +171,7 @@ type GenericItem struct {
 
 	// The template for the resource
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:EmbeddedResource
 	GenericTemplate runtime.RawExtension `json:"generictemplate,omitempty"`
 
 	// Array of resource requests

--- a/appwrapper-podgroup-sample.yaml
+++ b/appwrapper-podgroup-sample.yaml
@@ -14,7 +14,6 @@ spec:
         apiVersion: scheduling.sigs.k8s.io/v1alpha1
         kind: PodGroup
         metadata:
-          namespace: <APPWRAPPER_NAMESPACE>
           name: podgroup-1
         spec:
           minMember: 2
@@ -26,11 +25,8 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          namespace: <APPWRAPPER_NAMESPACE>
-          name: <APPWRAPPER_NAME>-1
+          name: appwrapper-podgroup-sample-1
           labels:
-            appwrapper.mcad.ibm.com/namespace: <APPWRAPPER_NAMESPACE>
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
             pod-group.scheduling.sigs.k8s.io: podgroup-1
         spec:
           schedulerName: scheduler-plugins-scheduler
@@ -52,11 +48,8 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          namespace: <APPWRAPPER_NAMESPACE>
-          name: <APPWRAPPER_NAME>-2
+          name: appwrapper-podgroup-sample-2
           labels:
-            appwrapper.mcad.ibm.com/namespace: <APPWRAPPER_NAMESPACE>
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
             pod-group.scheduling.sigs.k8s.io: podgroup-1
         spec:
           schedulerName: scheduler-plugins-scheduler

--- a/appwrapper-sample.yaml
+++ b/appwrapper-sample.yaml
@@ -18,11 +18,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          namespace: <APPWRAPPER_NAMESPACE>
-          name: <APPWRAPPER_NAME>-1
-          labels:
-            appwrapper.mcad.ibm.com/namespace: <APPWRAPPER_NAMESPACE>
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: appwrapper-sample-1
         spec:
           restartPolicy: Never
           containers:
@@ -42,11 +38,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          namespace: <APPWRAPPER_NAMESPACE>
-          name: <APPWRAPPER_NAME>-2
-          labels:
-            appwrapper.mcad.ibm.com/namespace: <APPWRAPPER_NAMESPACE>
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: appwrapper-sample-2
         spec:
           restartPolicy: Never
           containers:

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -104,6 +104,7 @@ spec:
                         generictemplate:
                           description: The template for the resource
                           type: object
+                          x-kubernetes-embedded-resource: true
                           x-kubernetes-preserve-unknown-fields: true
                         minavailable:
                           format: int32

--- a/test/e2e-kuttl-acct/steps/01-install.yaml
+++ b/test/e2e-kuttl-acct/steps/01-install.yaml
@@ -10,23 +10,18 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: <APPWRAPPER_NAME>-aw-01
+          name: aw-01
           namespace: start-up-03
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-03
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
         spec:
           replicas: 2
           selector:
             matchLabels:
-              app: <APPWRAPPER_NAME>-aw-01
+              app: aw-01
           template:
             metadata:
               namespace: start-up-03
               labels:
-                appwrapper.mcad.ibm.com/namespace: start-up-03
-                appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
-                app: <APPWRAPPER_NAME>-aw-01
+                app: aw-01
             spec:
               containers:
               - name: nginx

--- a/test/e2e-kuttl-acct/steps/02-install.yaml
+++ b/test/e2e-kuttl-acct/steps/02-install.yaml
@@ -10,23 +10,18 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: <APPWRAPPER_NAME>-aw-02
+          name: aw-02
           namespace: start-up-03
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-03
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
         spec:
           replicas: 2
           selector:
             matchLabels:
-              app: <APPWRAPPER_NAME>-aw-09
+              app: aw-02
           template:
             metadata:
               namespace: start-up-03
               labels:
-                appwrapper.mcad.ibm.com/namespace: start-up-03
-                appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
-                app: <APPWRAPPER_NAME>-aw-09
+                app: aw-02
             spec:
               containers:
               - name: nginx

--- a/test/e2e-kuttl/steps/02-install.yaml
+++ b/test/e2e-kuttl/steps/02-install.yaml
@@ -11,10 +11,7 @@ spec:
         kind: Pod
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-02-pod-01
         spec:
           restartPolicy: Never
           containers:

--- a/test/e2e-kuttl/steps/03-install.yaml
+++ b/test/e2e-kuttl/steps/03-install.yaml
@@ -13,10 +13,7 @@ spec:
         kind: Pod
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-03-pod-01
         spec:
           restartPolicy: Never
           containers:

--- a/test/e2e-kuttl/steps/04-install.yaml
+++ b/test/e2e-kuttl/steps/04-install.yaml
@@ -13,10 +13,7 @@ spec:
         kind: Pod
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-04-pod-01
         spec:
           restartPolicy: Never
           containers:
@@ -43,10 +40,7 @@ spec:
         kind: Pod
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-041
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-041-pod-01
         spec:
           restartPolicy: Never
           containers:

--- a/test/e2e-kuttl/steps/06-install.yaml
+++ b/test/e2e-kuttl/steps/06-install.yaml
@@ -13,10 +13,7 @@ spec:
         kind: Pod
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-06-pod-01
         spec:
           restartPolicy: Never
           containers:

--- a/test/e2e-kuttl/steps/07-install.yaml
+++ b/test/e2e-kuttl/steps/07-install.yaml
@@ -13,18 +13,11 @@ spec:
         kind: Job
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-pod-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-07-job-01
         spec:
           template:
             metadata:
               namespace: start-up-02
-              name: <APPWRAPPER_NAME>-pod-01
-              labels:
-                appwrapper.mcad.ibm.com/namespace: start-up-02
-                appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
             spec:
               containers:
               - name: busybox

--- a/test/e2e-kuttl/steps/08-install.yaml
+++ b/test/e2e-kuttl/steps/08-install.yaml
@@ -13,18 +13,11 @@ spec:
         kind: Job
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-aw-08
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-08-job-01
         spec:
           template:
             metadata:
               namespace: start-up-02
-              name: <APPWRAPPER_NAME>-aw-08
-              labels:
-                appwrapper.mcad.ibm.com/namespace: start-up-02
-                appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
             spec:
               containers:
               - name: busybox

--- a/test/e2e-kuttl/steps/09-install.yaml
+++ b/test/e2e-kuttl/steps/09-install.yaml
@@ -11,17 +11,11 @@ spec:
         kind: Job
         metadata:
           namespace: start-up-02
-          name: <APPWRAPPER_NAME>-batch-01
-          labels:
-            appwrapper.mcad.ibm.com/namespace: start-up-02
-            appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
+          name: aw-09-job-01
         spec:
           template:
             metadata:
               namespace: start-up-02
-              labels:
-                appwrapper.mcad.ibm.com/namespace: start-up-02
-                appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
             spec:
               containers:
               - name: busybox


### PR DESCRIPTION
This PR restores the EmbeddedResource validation on generic items preventing the creation of AppWrapper objects with malformed generic items.

This PR also updates the automatic label generation on nested resources to eliminate the need for placeholders. The following stanza is no longer necessary and should be elided from AppWrappers as it no longer passes validation:
```
labels:
  appwrapper.mcad.ibm.com/namespace: <APPWRAPPER_NAMESPACE>
  appwrapper.mcad.ibm.com: <APPWRAPPER_NAME>
``` 