### PR TITLE
Replace deprecated ginkgo flag: failFast -> fail-fast

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -31,7 +31,7 @@ setup_mcad_env
 
 mcad_up
 kuttl_tests
-go test ./test/e2e -v -timeout 130m -count=1 -ginkgo.failFast
+go test ./test/e2e -v -timeout 130m -count=1 -ginkgo.fail-fast
 
 RC=$?
 if [ ${RC} -eq 0 ]

--- a/hack/run-tests-on-cluster.sh
+++ b/hack/run-tests-on-cluster.sh
@@ -24,7 +24,7 @@ source ${ROOT_DIR}/hack/e2e-util.sh
 trap cleanup EXIT
 
 kuttl_tests
-go test ./test/e2e -v -timeout 130m -count=1 -ginkgo.failFast
+go test ./test/e2e -v -timeout 130m -count=1 -ginkgo.fail-fast
 
 RC=$?
 if [ ${RC} -eq 0 ]


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
It turns out we are using a deprecated ginkgo flag. A warning can be found in an e2e run in the CI. For example:
https://github.com/project-codeflare/mcad/actions/runs/7086222029/job/19286966606#step:10:349
This PR replaces the deprecated flag `failFast` with the new flag `fail-fast`

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->