### PR TITLE
Adjust requeue timestamp once deletion completes

### DIFF
--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -186,6 +186,7 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			// reset status to queued/idle
 			appWrapper.Status.Restarts += 1
+			appWrapper.Status.RequeueTimestamp = metav1.Now() // overwrite requeue decision time with completion time
 			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Queued, mcadv1beta1.Idle)
 		}
 


### PR DESCRIPTION
This PR resets the `RequeueTimestamp` once the deletion completes, so `PauseTimeInSeconds` is not reduced by the deletion time. 