### PR TITLE
Get only the client version of kubectl

### DIFF
--- a/hack/e2e-util.sh
+++ b/hack/e2e-util.sh
@@ -112,7 +112,7 @@ function check_prerequisites {
     echo "kubectl not installed, exiting."
     exit 1
   else
-    echo -n "found kubectl, " && kubectl version
+    echo -n "found kubectl, " && kubectl version --client
   fi
   kubectl kuttl version >/dev/null 2>&1
   if [ $? -ne 0 ]


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

This PR makes `e2e-util.sh` print only the client version of kubectl and ignore the server version.

This would eliminate errors like:
```
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```
ref: https://github.com/project-codeflare/mcad/actions/runs/7089085500/job/19293018769?pr=54#step:10:18


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->