### PR TITLE
eliminate testContext custom struct

### DIFF
--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -266,7 +266,7 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 		pass := false
 		for true {
 			aw1 := &arbv1.AppWrapper{}
-			err := ctx.client.Get(ctx.ctx, client.ObjectKey{Namespace: aw.Namespace, Name: aw.Name}, aw1)
+			err := ctx.client.Get(ctx, client.ObjectKey{Namespace: aw.Namespace, Name: aw.Name}, aw1)
 			if err != nil {
 				fmt.Fprint(GinkgoWriter, "Error getting status")
 			}
@@ -341,7 +341,7 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 		var pass = false
 		for true {
 			aw2Update := &arbv1.AppWrapper{}
-			err := ctx.client.Get(ctx.ctx, client.ObjectKey{Namespace: aw2.Namespace, Name: aw2.Name}, aw2Update)
+			err := ctx.client.Get(ctx, client.ObjectKey{Namespace: aw2.Namespace, Name: aw2.Name}, aw2Update)
 			if err != nil {
 				fmt.Fprintf(GinkgoWriter, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Error getting AW update %v", err)
 			}
@@ -425,11 +425,11 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 		Expect(err1).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: aw-test-jobtimeout-with-comp-1")
 		var aw1 *arbv1.AppWrapper
 		var err error
-		aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx.ctx, aw.Name, metav1.GetOptions{})
+		aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx, aw.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "Expecting no error when getting app wrapper status")
 		fmt.Fprintf(GinkgoWriter, "[e2e] status of app wrapper: %v.\n", aw1.Status)
 		for aw1.Status.State != arbv1.AppWrapperStateFailed {
-			aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx.ctx, aw.Name, metav1.GetOptions{})
+			aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx, aw.Name, metav1.GetOptions{})
 			if aw.Status.State == arbv1.AppWrapperStateFailed {
 				break
 			}

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -36,17 +37,18 @@ var _ = BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 })
 
-var _ = Describe("AppWrapper E2E Test", func() {
-	var context *testContext
+var _ = Describe("AppWrapper E2E Tests", func() {
+	var ctx context.Context
 	var appwrappers []*arbv1.AppWrapper
 
 	BeforeEach(func() {
-		context = initTestContext()
 		appwrappers = []*arbv1.AppWrapper{}
+		ctx = extendContextWithClient(context.Background())
+		ensureNamespaceExists(ctx)
 	})
 
 	AfterEach(func() {
-		cleanupTestObjectsPtr(context, &appwrappers)
+		cleanupTestObjectsPtr(ctx, &appwrappers)
 	})
 
 	Describe("Queueing and Preemption", func() {
@@ -54,18 +56,18 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		It("MCAD CPU Accounting Test", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Accounting Test - Started.\n")
 			// This should fill up the worker node and most of the master node
-			aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+			aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu"))
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred(), "Ready pods are expected for app wrapper: aw-deployment-2-550cpu")
 
 			// This should fill up the master node
-			aw2 := createDeploymentAWwith350CPU(context, appendRandomString("aw-deployment-2-350cpu"))
+			aw2 := createDeploymentAWwith350CPU(ctx, appendRandomString("aw-deployment-2-350cpu"))
 			appwrappers = append(appwrappers, aw2)
 
 			// Using quiet mode due to creating of pods in earlier step.
-			err = waitAWReadyQuiet(context, aw2)
+			err = waitAWReadyQuiet(ctx, aw2)
 			Expect(err).NotTo(HaveOccurred(), "Ready pods are expected for app wrapper: aw-deployment-2-350cpu")
 			fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Accounting Test - Completed. Awaiting app wrapper cleanup...\n")
 		})
@@ -76,25 +78,25 @@ var _ = Describe("AppWrapper E2E Test", func() {
 				fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Preemption Test - Started.\n")
 
 				// This should fill up the worker node and most of the master node
-				aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+				aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu"))
 				appwrappers = append(appwrappers, aw)
-				err := waitAWPodsReady(context, aw)
+				err := waitAWPodsReady(ctx, aw)
 				Expect(err).NotTo(HaveOccurred())
 
 				// This should not fit on cluster
-				aw2 := createDeploymentAWwith426CPU(context, appendRandomString("aw-deployment-2-426cpu"))
+				aw2 := createDeploymentAWwith426CPU(ctx, appendRandomString("aw-deployment-2-426cpu"))
 				appwrappers = append(appwrappers, aw2)
-				err = waitAWAnyPodsExists(context, aw2)
+				err = waitAWAnyPodsExists(ctx, aw2)
 				// With improved accounting, no pods will be spawned
 				Expect(err).To(HaveOccurred())
 
 				// This should fit on cluster, initially queued because of aw2 above but should eventually
 				// run after prevention of aw2 above.
-				aw3 := createDeploymentAWwith425CPU(context, "aw-deployment-2-425cpu")
+				aw3 := createDeploymentAWwith425CPU(ctx, "aw-deployment-2-425cpu")
 				appwrappers = append(appwrappers, aw3)
 
 				// Since preemption takes some time, increasing timeout wait time to 2 minutes
-				err = waitAWPodsExists(context, aw3, 2*time.Minute)
+				err = waitAWPodsExists(ctx, aw3, 2*time.Minute)
 				Expect(err).NotTo(HaveOccurred(), "Expecting pods for app wrapper : aw-deployment-2-425cpu")
 			})
 		*/
@@ -109,10 +111,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 				// The job should be requeued 3 times before it finishes since the wait time is doubled each time the job is requeued (i.e., initially it waits
 				// for 1 minutes before requeuing, then 2 minutes, and then 4 minutes). Since the init containers take 3 minutes
 				// and 20 seconds to finish, a 4 minute wait should be long enough to finish the job successfully
-				aw := createJobAWWithInitContainer(context, "aw-job-3-init-container-1", 60, "exponential", 0)
+				aw := createJobAWWithInitContainer(ctx, "aw-job-3-init-container-1", 60, "exponential", 0)
 				appwrappers = append(appwrappers, aw)
 
-				err := waitAWPodsCompleted(context, aw, 8*time.Minute) // This test waits for 14 minutes to make sure all PODs complete
+				err := waitAWPodsCompleted(ctx, aw, 8*time.Minute) // This test waits for 14 minutes to make sure all PODs complete
 				Expect(err).NotTo(HaveOccurred(), "Waiting for the pods to be completed")
 			})
 		*/
@@ -123,71 +125,71 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			// Create a job with init containers that need 200 seconds to be ready before the container starts.
 			// The requeuing mechanism is set to fire after 1 second (plus the 60 seconds time interval of the background thread)
 			// Within 5 minutes, the AppWrapper will be requeued up to 3 times at which point it will be deleted
-			aw := createJobAWWithInitContainer(context, "aw-job-3-init-container", 1, "none", 3)
+			aw := createJobAWWithInitContainer(ctx, "aw-job-3-init-container", 1, "none", 3)
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsCompleted(context, aw, 200*time.Second)
+			err := waitAWPodsCompleted(ctx, aw, 200*time.Second)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Create AppWrapper - StatefulSet Only - 2 Pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - StatefulSet Only - 2 Pods - Started.\n")
 
-			aw := createStatefulSetAW(context, "aw-statefulset-2")
+			aw := createStatefulSetAW(ctx, "aw-statefulset-2")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Create AppWrapper - Generic StatefulSet Only - 2 Pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Generic StatefulSet Only - 2 Pods - Started.\n")
 
-			aw := createGenericStatefulSetAW(context, "aw-generic-statefulset-2")
+			aw := createGenericStatefulSetAW(ctx, "aw-generic-statefulset-2")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Create AppWrapper - Deployment Only - 3 Pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Deployment Only 3 Pods - Started.\n")
 
-			aw := createDeploymentAW(context, "aw-deployment-3")
+			aw := createDeploymentAW(ctx, "aw-deployment-3")
 			appwrappers = append(appwrappers, aw)
 
 			fmt.Fprintf(GinkgoWriter, "[e2e] Awaiting %d pods running for AW %s.\n", aw.Spec.Scheduling.MinAvailable, aw.Name)
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Create AppWrapper - Generic Deployment Only - 3 pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Generic Deployment Only - 3 pods - Started.\n")
 
-			aw := createGenericDeploymentAW(context, "aw-generic-deployment-3")
+			aw := createGenericDeploymentAW(ctx, "aw-generic-deployment-3")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Create AppWrapper  - PodTemplate Only - 2 Pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - PodTemplate Only - 2 Pods - Started.\n")
 
-			aw := createPodTemplateAW(context, "aw-podtemplate-2")
+			aw := createPodTemplateAW(ctx, "aw-podtemplate-2")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Create AppWrapper  - Generic Pod Only - 1 Pod", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Generic Pod Only - 1 Pod - Started.\n")
 
-			aw := createGenericPodAW(context, "aw-generic-pod-1")
+			aw := createGenericPodAW(ctx, "aw-generic-pod-1")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -197,10 +199,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			It("Create AppWrapper  - Generic Pod Too Big - 1 Pod", func() {
 				fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Generic Pod Too Big - 1 Pod - Started.\n")
 
-				aw := createGenericPodTooBigAW(context, "aw-generic-big-pod-1")
+				aw := createGenericPodTooBigAW(ctx, "aw-generic-big-pod-1")
 				appwrappers = append(appwrappers, aw)
 
-				err := waitAWAnyPodsExists(context, aw)
+				err := waitAWAnyPodsExists(ctx, aw)
 				Expect(err).To(HaveOccurred())
 			})
 		*/
@@ -212,17 +214,17 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		It("Create AppWrapper- Bad PodTemplate", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper- Bad PodTemplate - Started.\n")
 
-			aw := createBadPodTemplateAW(context, "aw-bad-podtemplate-2")
+			aw := createBadPodTemplateAW(ctx, "aw-bad-podtemplate-2")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsExists(context, aw, 30*time.Second)
+			err := waitAWPodsExists(ctx, aw, 30*time.Second)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("Create AppWrapper  - Bad Generic PodTemplate Only", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Bad Generic PodTemplate Only - Started.\n")
 
-			aw, err := createBadGenericPodTemplateAW(context, "aw-generic-podtemplate-2")
+			aw, err := createBadGenericPodTemplateAW(ctx, "aw-generic-podtemplate-2")
 			if err == nil {
 				appwrappers = append(appwrappers, aw)
 			}
@@ -232,10 +234,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		It("Create AppWrapper  - Bad Generic Pod Only", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Bad Generic Pod Only - Started.\n")
 
-			aw := createBadGenericPodAW(context, "aw-bad-generic-pod-1")
+			aw := createBadGenericPodAW(ctx, "aw-bad-generic-pod-1")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsCompleted(context, aw, 10*time.Second)
+			err := waitAWPodsCompleted(ctx, aw, 10*time.Second)
 			Expect(err).To(HaveOccurred())
 
 		})
@@ -243,10 +245,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		It("Create AppWrapper  - Bad Generic Item Only", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Bad Generic Item Only - Started.\n")
 
-			aw := createBadGenericItemAW(context, "aw-bad-generic-item-1")
+			aw := createBadGenericItemAW(ctx, "aw-bad-generic-item-1")
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsCompleted(context, aw, 10*time.Second)
+			err := waitAWPodsCompleted(ctx, aw, 10*time.Second)
 			Expect(err).To(HaveOccurred())
 
 		})
@@ -256,15 +258,15 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("Create AppWrapper  - Check failed pod status", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Check failed pod status - Started.\n")
 
-		aw := createPodCheckFailedStatusAW(context, "aw-checkfailedstatus-1")
+		aw := createPodCheckFailedStatusAW(ctx, "aw-checkfailedstatus-1")
 		appwrappers = append(appwrappers, aw)
 
-		err := waitAWPodsReady(context, aw)
+		err := waitAWPodsReady(ctx, aw)
 		Expect(err).NotTo(HaveOccurred())
 		pass := false
 		for true {
 			aw1 := &arbv1.AppWrapper{}
-			err := context.client.Get(context.ctx, client.ObjectKey{Namespace: aw.Namespace, Name: aw.Name}, aw1)
+			err := ctx.client.Get(ctx.ctx, client.ObjectKey{Namespace: aw.Namespace, Name: aw.Name}, aw1)
 			if err != nil {
 				fmt.Fprint(GinkgoWriter, "Error getting status")
 			}
@@ -285,14 +287,14 @@ var _ = Describe("AppWrapper E2E Test", func() {
 
 		// This should fit on cluster with customPodResources matching deployment resource demands so AW pods are created
 		aw := createGenericDeploymentCustomPodResourcesWithCPUAW(
-			context, "aw-deployment-2-550-vs-550-cpu", "550m", "550m", 2, 60)
+			ctx, "aw-deployment-2-550-vs-550-cpu", "550m", "550m", 2, 60)
 
 		appwrappers = append(appwrappers, aw)
 
-		err := waitAWAnyPodsExists(context, aw)
+		err := waitAWAnyPodsExists(ctx, aw)
 		Expect(err).NotTo(HaveOccurred(), "Expecting any pods for app wrapper: aw-deployment-2-550-vs-550-cpu")
 
-		err = waitAWPodsReady(context, aw)
+		err = waitAWPodsReady(ctx, aw)
 		Expect(err).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: aw-deployment-2-550-vs-550-cpu")
 	})
 
@@ -301,37 +303,37 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Started.\n")
 
 		// This should fill up the worker node and most of the master node
-		aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+		aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu"))
 		appwrappers = append(appwrappers, aw)
-		err := waitAWPodsReady(context, aw)
+		err := waitAWPodsReady(ctx, aw)
 		Expect(err).NotTo(HaveOccurred(), "Expecting pods for app wrapper: aw-deployment-2-550cpu")
 
 		// This should not fit on any node but should dispatch because there is enough aggregated resources.
 		aw2 := createGenericDeploymentCustomPodResourcesWithCPUAW(
-			context, appendRandomString("aw-ff-deployment-1-850-cpu"), "850m", "850m", 1, 60)
+			ctx, appendRandomString("aw-ff-deployment-1-850-cpu"), "850m", "850m", 1, 60)
 
 		appwrappers = append(appwrappers, aw2)
 
-		err = waitAWAnyPodsExists(context, aw2)
+		err = waitAWAnyPodsExists(ctx, aw2)
 		Expect(err).NotTo(HaveOccurred(), "Expecting pending pods for app wrapper: aw-ff-deployment-1-850-cpu")
 
-		err = waitAWPodsPending(context, aw2)
+		err = waitAWPodsPending(ctx, aw2)
 		Expect(err).NotTo(HaveOccurred(), "Expecting pending pods (try 2) for app wrapper: aw-ff-deployment-1-850-cpu")
 		fmt.Fprintf(GinkgoWriter, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Pending pods found for app wrapper aw-ff-deployment-1-850-cpu\n")
 
 		// This should fit on cluster after AW aw-deployment-1-850-cpu above is automatically preempted on
 		// scheduling failure
 		aw3 := createGenericDeploymentCustomPodResourcesWithCPUAW(
-			context, appendRandomString("aw-ff-deployment-2-340-cpu"), "340m", "340m", 2, 60)
+			ctx, appendRandomString("aw-ff-deployment-2-340-cpu"), "340m", "340m", 2, 60)
 
 		appwrappers = append(appwrappers, aw3)
 
 		// Wait for pods to get created, assumes preemption around 10 minutes
-		err = waitAWPodsExists(context, aw3, 720000*time.Millisecond)
+		err = waitAWPodsExists(ctx, aw3, 720000*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred(), "Expecting pods for app wrapper: aw-ff-deployment-2-340-cpu")
 		fmt.Fprintf(GinkgoWriter, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Pods not found for app wrapper aw-ff-deployment-2-340-cpu\n")
 
-		err = waitAWPodsReady(context, aw3)
+		err = waitAWPodsReady(ctx, aw3)
 		Expect(err).NotTo(HaveOccurred(), "Expecting no pods for app wrapper: aw-ff-deployment-2-340-cpu")
 		fmt.Fprintf(GinkgoWriter, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Ready pods found for app wrapper aw-ff-deployment-2-340-cpu\n")
 
@@ -339,7 +341,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		var pass = false
 		for true {
 			aw2Update := &arbv1.AppWrapper{}
-			err := context.client.Get(context.ctx, client.ObjectKey{Namespace: aw2.Namespace, Name: aw2.Name}, aw2Update)
+			err := ctx.client.Get(ctx.ctx, client.ObjectKey{Namespace: aw2.Namespace, Name: aw2.Name}, aw2Update)
 			if err != nil {
 				fmt.Fprintf(GinkgoWriter, "[e2e] MCAD Scheduling Fail Fast Preemption Test - Error getting AW update %v", err)
 			}
@@ -368,22 +370,22 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] MCAD Bad Custom Pod Resources vs. Deployment Pod Resource Not Queuing Test - Started.\n")
 
 			// This should fill up the worker node and most of the master node
-			aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+			aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu"))
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: aw-deployment-2-550cpu")
 
 			// This should not fit on cluster but customPodResources is incorrect so AW pods are created
 			aw2 := createGenericDeploymentCustomPodResourcesWithCPUAW(
-				context, appendRandomString("aw-deployment-2-425-vs-426-cpu"), "425m", "426m", 2, 60)
+				ctx, appendRandomString("aw-deployment-2-425-vs-426-cpu"), "425m", "426m", 2, 60)
 
 			appwrappers = append(appwrappers, aw2)
 
-			err = waitAWAnyPodsExists(context, aw2)
+			err = waitAWAnyPodsExists(ctx, aw2)
 			Expect(err).NotTo(HaveOccurred(), "Not expecting pods to exist for app wrapper: aw-deployment-2-425-vs-426-cpu")
 
-			err = waitAWPodsReady(context, aw2)
+			err = waitAWPodsReady(ctx, aw2)
 			Expect(err).To(HaveOccurred(), "Not expecting pods to exist for app wrapper: aw-deployment-2-425-vs-426-cpu")
 		})
 	*/
@@ -394,20 +396,20 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] MCAD Bad Custom Pod Resources vs. Deployment Pod Resource Queuing Test 2 - Started.\n")
 
 			// This should fill up the worker node and most of the master node
-			aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu-2"))
+			aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu-2"))
 			appwrappers = append(appwrappers, aw)
 
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred(), "Waiting for pods to be ready for app wrapper: aw-deployment-2-550cpu")
 
 			// This should fit on cluster but customPodResources is incorrect so AW pods are not created
 			// NOTE: with deployment controlled removed this test case is invalid.
 			// Users should keep custompodresources equal to container resources.
 			aw2 := createGenericDeploymentCustomPodResourcesWithCPUAW(
-				context, appendRandomString("aw-deployment-2-427-vs-425-cpu"), "4270m", "425m", 2, 60)
+				ctx, appendRandomString("aw-deployment-2-427-vs-425-cpu"), "4270m", "425m", 2, 60)
 
 			appwrappers = append(appwrappers, aw2)
-			err = waitAWAnyPodsExists(context, aw2)
+			err = waitAWAnyPodsExists(ctx, aw2)
 			Expect(err).To(HaveOccurred(), "Waiting for no pods to exist for app wrapper: aw-deployment-2-427-vs-425-cpu")
 
 		})
@@ -417,17 +419,17 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD app wrapper timeout Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD app wrapper timeout Test - Started.\n")
 
-		aw := createGenericAWTimeoutWithStatus(context, "aw-test-jobtimeout-with-comp-1")
+		aw := createGenericAWTimeoutWithStatus(ctx, "aw-test-jobtimeout-with-comp-1")
 		appwrappers = append(appwrappers, aw)
-		err1 := waitAWPodsReady(context, aw)
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: aw-test-jobtimeout-with-comp-1")
 		var aw1 *arbv1.AppWrapper
 		var err error
-		aw1, err = context.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(context.ctx, aw.Name, metav1.GetOptions{})
+		aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx.ctx, aw.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "Expecting no error when getting app wrapper status")
 		fmt.Fprintf(GinkgoWriter, "[e2e] status of app wrapper: %v.\n", aw1.Status)
 		for aw1.Status.State != arbv1.AppWrapperStateFailed {
-			aw1, err = context.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(context.ctx, aw.Name, metav1.GetOptions{})
+			aw1, err = ctx.karclient.WorkloadV1beta1().AppWrappers(aw.Namespace).Get(ctx.ctx, aw.Name, metav1.GetOptions{})
 			if aw.Status.State == arbv1.AppWrapperStateFailed {
 				break
 			}
@@ -441,10 +443,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD Job Completion Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Completion Test - Started.\n")
 
-		aw := createGenericJobAWWithStatus(context, "aw-test-job-with-comp-1")
-		err1 := waitAWPodsReady(context, aw)
+		aw := createGenericJobAWWithStatus(ctx, "aw-test-job-with-comp-1")
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred())
-		Eventually(AppWrapper(context, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateCompleted)))
+		Eventually(AppWrapper(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateCompleted)))
 		appwrappers = append(appwrappers, aw)
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Completion Test - Completed.\n")
 	})
@@ -453,15 +455,15 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	/*  TODO: DAVE: Status.State
 	It("MCAD Multi-Item Job Completion Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Multi-Item Job Completion Test - Started.\n")
-		context := initTestContext()
+		ctx := initTestContext()
 		var appwrappers []*arbv1.AppWrapper
 		appwrappersPtr := &appwrappers
-		defer cleanupTestObjectsPtr(context, appwrappersPtr)
+		defer cleanupTestObjectsPtr(ctx, appwrappersPtr)
 
-		aw := createGenericJobAWWithMultipleStatus(context, "aw-test-job-with-comp-ms-21")
-		err1 := waitAWPodsReady(context, aw)
+		aw := createGenericJobAWWithMultipleStatus(ctx, "aw-test-job-with-comp-ms-21")
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: 'aw-test-job-with-comp-ms-21'")
-		Eventually(AppWrapper(context, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateCompleted)))
+		Eventually(AppWrapper(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateCompleted)))
 		appwrappers = append(appwrappers, aw)
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Multi-Item Job Completion Test - Completed.\n")
 	})
@@ -470,8 +472,8 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD GenericItem Without Status Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD GenericItem Without Status Test - Started.\n")
 
-		aw := createAWGenericItemWithoutStatus(context, "aw-test-job-with-comp-44")
-		err1 := waitAWPodsReady(context, aw)
+		aw := createAWGenericItemWithoutStatus(ctx, "aw-test-job-with-comp-44")
+		err1 := waitAWPodsReady(ctx, aw)
 		appwrappers = append(appwrappers, aw)
 		fmt.Fprintf(GinkgoWriter, "The error is: %v", err1)
 		Expect(err1).To(HaveOccurred(), "Expecting for pods not to be ready for app wrapper: aw-test-job-with-comp-44")
@@ -482,15 +484,15 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD Job Completion No-requeue Test", Label("slow"), func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Completion No-requeue Test - Started.\n")
 
-		aw := createGenericJobAWWithScheduleSpec(context, "aw-test-job-with-scheduling-spec")
-		err1 := waitAWPodsReady(context, aw)
+		aw := createGenericJobAWWithScheduleSpec(ctx, "aw-test-job-with-scheduling-spec")
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred(), "Waiting for pods to be ready")
-		err2 := waitAWPodsCompleted(context, aw, 90*time.Second)
+		err2 := waitAWPodsCompleted(ctx, aw, 90*time.Second)
 		Expect(err2).NotTo(HaveOccurred(), "Waiting for pods to be completed")
 
 		// Once pods are completed, we wait for them to see if they change their status to anything BUT "Completed"
 		// which SHOULD NOT happen because the job is done
-		err3 := waitAWPodsNotCompleted(context, aw)
+		err3 := waitAWPodsNotCompleted(ctx, aw)
 		Expect(err3).To(HaveOccurred(), "Waiting for pods not to be completed")
 
 		appwrappers = append(appwrappers, aw)
@@ -502,10 +504,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD Job Large Compute Requirement Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Large Compute Requirement Test - Started.\n")
 
-		aw := createGenericJobAWtWithLargeCompute(context, "aw-test-job-with-large-comp-1")
-		err1 := waitAWPodsReady(context, aw)
+		aw := createGenericJobAWtWithLargeCompute(ctx, "aw-test-job-with-large-comp-1")
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred())
-		Eventually(AppWrapper(context, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateEnqueued)))
+		Eventually(AppWrapper(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateEnqueued)))
 		appwrappers = append(appwrappers, aw)
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Job Large Compute Requirement Test - Completed.\n")
 	})
@@ -517,17 +519,17 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Accounting Queuing Test - Started.\n")
 
 			// This should fill up the worker node and most of the master node
-			aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+			aw := createDeploymentAWwith550CPU(ctx, appendRandomString("aw-deployment-2-550cpu"))
 			appwrappers = append(appwrappers, aw)
-			err := waitAWPodsReady(context, aw)
+			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred(), "Waiting for pods to be ready for app wrapper: aw-deployment-2-550cpu")
 
 			// This should not fit on cluster
 			// there may be a false positive dispatch which will cause MCAD to requeue AW
-			aw2 := createDeploymentAWwith426CPU(context, appendRandomString("aw-deployment-2-426cpu"))
+			aw2 := createDeploymentAWwith426CPU(ctx, appendRandomString("aw-deployment-2-426cpu"))
 			appwrappers = append(appwrappers, aw2)
 
-			err = waitAWPodsReady(context, aw2)
+			err = waitAWPodsReady(ctx, aw2)
 			Expect(err).To(HaveOccurred(), "No pods for app wrapper `aw-deployment-2-426cpu` are expected.")
 		})
 	*/
@@ -536,11 +538,11 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD Deployment RunningHoldCompletion Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Deployment RunningHoldCompletion Test - Started.\n")
 
-		aw := createGenericDeploymentAWWithMultipleItems(context, "aw-deployment-rhc")
+		aw := createGenericDeploymentAWWithMultipleItems(ctx, "aw-deployment-rhc")
 		appwrappers = append(appwrappers, aw)
-		err1 := waitAWPodsReady(context, aw)
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred(), "Expecting pods to be ready for app wrapper: aw-deployment-rhc")
-		Eventually(AppWrapper(context, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateRunningHoldCompletion)))
+		Eventually(AppWrapper(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateRunningHoldCompletion)))
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Deployment RuningHoldCompletion Test - Completed. Awaiting app wrapper cleanup.\n")
 	})
 	*/
@@ -549,10 +551,10 @@ var _ = Describe("AppWrapper E2E Test", func() {
 	It("MCAD Service no RunningHoldCompletion or Complete Test", func() {
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Service no RunningHoldCompletion or Complete Test - Started.\n")
 
-		aw := createGenericServiceAWWithNoStatus(context, appendRandomString("aw-deployment-2-status"))
-		err1 := waitAWPodsReady(context, aw)
+		aw := createGenericServiceAWWithNoStatus(ctx, appendRandomString("aw-deployment-2-status"))
+		err1 := waitAWPodsReady(ctx, aw)
 		Expect(err1).NotTo(HaveOccurred())
-		Eventually(AppWrapper(context, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateActive)))
+		Eventually(AppWrapper(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(WithTransform(AppWrapperState, Equal(arbv1.AppWrapperStateActive)))
 		appwrappers = append(appwrappers, aw)
 		fmt.Fprintf(os.Stdout, "[e2e] MCAD Service no RuningHoldCompletion or Complete Test - Completed.\n")
 	})
@@ -577,7 +579,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 				if ((i+1)%modDivisor) == 0 || i == 0 {
 					fmt.Fprintf(GinkgoWriter, "[e2e] Creating AW %s with %s cpu and %d replica(s).\n", name, cpuDemand, replicas)
 				}
-				aw := createGenericDeploymentWithCPUAW(context, name, cpuDemand, replicas)
+				aw := createGenericDeploymentWithCPUAW(ctx, name, cpuDemand, replicas)
 				appwrappers = append(appwrappers, aw)
 			}
 			// Give the deployments time to create pods
@@ -588,7 +590,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 				t := time.Now()
 				toCheckAWS := make([]*arbv1.AppWrapper, 0, len(appwrappers))
 				for _, aw := range uncompletedAWS {
-					err := waitAWPodsReadyEx(context, aw, 100*time.Millisecond, int(aw.Spec.Scheduling.MinAvailable), true)
+					err := waitAWPodsReadyEx(ctx, aw, 100*time.Millisecond, int(aw.Spec.Scheduling.MinAvailable), true)
 					if err != nil {
 						toCheckAWS = append(toCheckAWS, aw)
 					}

--- a/test/e2e/quota.go
+++ b/test/e2e/quota.go
@@ -20,6 +20,8 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,31 +35,32 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("Quota E2E Test", func() {
-	var context *testContext
+	var ctx context.Context
 	var appwrappers []*arbv1.AppWrapper
 
 	BeforeEach(func() {
-		context = initTestContext()
 		appwrappers = []*arbv1.AppWrapper{}
+		ctx = extendContextWithClient(context.Background())
+		ensureNamespaceExists(ctx)
 	})
 
 	AfterEach(func() {
-		cleanupTestObjectsPtr(context, &appwrappers)
+		cleanupTestObjectsPtr(ctx, &appwrappers)
 	})
 
 	It("Create AppWrapper  - Generic Pod Only - Sufficient Quota 1 Tree", func() {
-		aw := createGenericPodAW(context, "aw-generic-pod-1")
+		aw := createGenericPodAW(ctx, "aw-generic-pod-1")
 		appwrappers = append(appwrappers, aw)
 
-		err := waitAWPodsReady(context, aw)
+		err := waitAWPodsReady(ctx, aw)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Create AppWrapper  - Generic Pod Only - Insufficient Quota 1 Tree", func() {
-		aw := createGenericPodAWCustomDemand(context, "aw-generic-large-cpu-pod-1", "9000m")
+		aw := createGenericPodAWCustomDemand(ctx, "aw-generic-large-cpu-pod-1", "9000m")
 		appwrappers = append(appwrappers, aw)
 
-		err := waitAWPodsReady(context, aw)
+		err := waitAWPodsReady(ctx, aw)
 		Expect(err).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
1. store the kube client as a Value in context.Context
2. use constant for test namespace
