### PR TITLE
Add default forceDeletionTimeInSeconds and pauseTimeInSeconds

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -65,7 +65,7 @@ type RequeuingSpec struct {
 	DoNotUseInitialTimeInSeconds int64 `json:"initialTimeInSeconds,omitempty"`
 
 	// Initial waiting time before requeuing conditions are checked
-	// +kubebuilder:default=300
+	// +kubebuilder:default=270
 	TimeInSeconds int64 `json:"timeInSeconds,omitempty"`
 
 	// +kubebuilder:default=0
@@ -81,10 +81,12 @@ type RequeuingSpec struct {
 	// +kubebuilder:default=0
 	MaxNumRequeuings int32 `json:"maxNumRequeuings,omitempty"`
 
-	// Enable forced deletion after delay if nonzero
+	// Enable forced deletion after delay if greater than zero
+	// +kubebuilder:default=570
 	ForceDeletionTimeInSeconds int64 `json:"forceDeletionTimeInSeconds,omitempty"`
 
-	// Wait time before trying to dispatch again after requeuing
+	// Waiting time before trying to dispatch again after requeuing
+	// +kubebuilder:default=90
 	PauseTimeInSeconds int64 `json:"pauseTimeInSeconds,omitempty"`
 }
 

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -153,7 +153,9 @@ spec:
                     description: Requeuing specification
                     properties:
                       forceDeletionTimeInSeconds:
-                        description: Enable forced deletion after delay if nonzero
+                        default: 570
+                        description: Enable forced deletion after delay if greater
+                          than zero
                         format: int64
                         type: integer
                       growthType:
@@ -176,12 +178,13 @@ spec:
                         format: int32
                         type: integer
                       pauseTimeInSeconds:
-                        description: Wait time before trying to dispatch again after
-                          requeuing
+                        default: 90
+                        description: Waiting time before trying to dispatch again
+                          after requeuing
                         format: int64
                         type: integer
                       timeInSeconds:
-                        default: 300
+                        default: 270
                         description: Initial waiting time before requeuing conditions
                           are checked
                         format: int64

--- a/internal/controller/resource_manager.go
+++ b/internal/controller/resource_manager.go
@@ -200,7 +200,7 @@ func (r *AppWrapperReconciler) deleteResources(ctx context.Context, appWrapper *
 		}
 		remaining++ // no error deleting resource, resource therefore still exists
 	}
-	if appWrapper.Spec.Scheduling.Requeuing.ForceDeletionTimeInSeconds == 0 {
+	if appWrapper.Spec.Scheduling.Requeuing.ForceDeletionTimeInSeconds <= 0 {
 		// force deletion is not enabled, return true iff no resources were found
 		return remaining == 0
 	}


### PR DESCRIPTION
This PR ensures MCAD does not immediately try to redispatch an appwrapper after requeuing. It also turn on force deletion by default after a significant delay (570s).