### PR TITLE
Tweak and document minAvailable behavior

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -46,7 +46,10 @@ type AppWrapperSpec struct {
 type SchedulingSpec struct {
 	DoNotUseNodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Minimum number of expected running and successful pods
+	// Minimum number of expected running and successful pods.
+	// Set to -1 to disable pod monitoring, cleanup on failure, and termination detection based on pod counts.
+	// Set to 0 to enable pod monitoring (at least 1 pod), cleanup on failure, and disable termination detection.
+	// Set to n>=1 to enable pod monitoring (at least n pods), cleanup on failure, and termination detection.
 	MinAvailable int32 `json:"minAvailable,omitempty"`
 
 	// Requeuing specification

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -142,7 +142,11 @@ spec:
                     type: object
                   minAvailable:
                     description: Minimum number of expected running and successful
-                      pods
+                      pods. Set to -1 to disable pod monitoring, cleanup on failure,
+                      and termination detection based on pod counts. Set to 0 to enable
+                      pod monitoring (at least 1 pod), cleanup on failure, and disable
+                      termination detection. Set to n>=1 to enable pod monitoring
+                      (at least n pods), cleanup on failure, and termination detection.
                     format: int32
                     type: integer
                   nodeSelector:


### PR DESCRIPTION
This PR enables pod monitoring and cleanup on failure by default (`minAvailable == 0`) without enabling termination detection based on pod counts. The AppWrapper will be considered unhealthy in this absence of a running or successful pod.

With `minAvailable < 0`, pod monitoring, cleanup, and termination detection are disabled.

With `minAvailable > 0`, pod monitoring, cleanup, and termination detection are enabled with at least `n` pods expected to run and succeed.