### PR TITLE
Consistently rename AppWrapper phase to state

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -95,8 +95,8 @@ type RequeuingSpec struct {
 
 // AppWrapperStatus defines the observed state of AppWrapper
 type AppWrapperStatus struct {
-	// Phase
-	Phase AppWrapperPhase `json:"state,omitempty"`
+	// State
+	State AppWrapperState `json:"state,omitempty"`
 
 	// Status of wrapped resources
 	Step AppWrapperStep `json:"step,omitempty"`
@@ -117,27 +117,27 @@ type AppWrapperStatus struct {
 	TransitionCount int32 `json:"transitionCount,omitempty"`
 }
 
-// AppWrapperPhase is the label for the AppWrapper status
-type AppWrapperPhase string
+// AppWrapperState is the label for the AppWrapper status
+type AppWrapperState string
 
 // AppWrapperState is the status of wrapped resources
 type AppWrapperStep string
 
 const (
 	// Initial state upon creation of the AppWrapper object
-	Empty AppWrapperPhase = ""
+	Empty AppWrapperState = ""
 
 	// AppWrapper has not been dispatched yet or has been requeued
-	Queued AppWrapperPhase = "Pending"
+	Queued AppWrapperState = "Pending"
 
 	// AppWrapper has been dispatched and not requeued
-	Running AppWrapperPhase = "Running"
+	Running AppWrapperState = "Running"
 
 	// AppWrapper completed successfully
-	Succeeded AppWrapperPhase = "Completed"
+	Succeeded AppWrapperState = "Completed"
 
 	// AppWrapper failed and is not requeued
-	Failed AppWrapperPhase = "Failed"
+	Failed AppWrapperState = "Failed"
 
 	// Resources are not deployed
 	Idle AppWrapperStep = ""
@@ -198,7 +198,7 @@ type CustomPodResource struct {
 	DoNotUseLimits v1.ResourceList `json:"limits,omitempty"`
 }
 
-// Phase transition
+// State transition
 type AppWrapperTransition struct {
 	// Timestamp
 	Time metav1.Time `json:"time"`
@@ -206,8 +206,8 @@ type AppWrapperTransition struct {
 	// Reason
 	Reason string `json:"reason,omitempty"`
 
-	// Phase entered
-	Phase AppWrapperPhase `json:"state"`
+	// State entered
+	State AppWrapperState `json:"state"`
 
 	// Status of wrapped resources
 	Step AppWrapperStep `json:"step,omitempty"`

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -609,7 +609,7 @@ spec:
                 format: int32
                 type: integer
               state:
-                description: Phase
+                description: State
                 type: string
               step:
                 description: Status of wrapped resources
@@ -621,13 +621,13 @@ spec:
               transitions:
                 description: Transition log
                 items:
-                  description: Phase transition
+                  description: State transition
                   properties:
                     reason:
                       description: Reason
                       type: string
                     state:
-                      description: Phase entered
+                      description: State entered
                       type: string
                     step:
                       description: Status of wrapped resources

--- a/internal/controller/cache.go
+++ b/internal/controller/cache.go
@@ -25,20 +25,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// We cache AppWrapper phases because the reconciler cache does not immediately reflect updates.
+// We cache AppWrappers because the reconciler cache does not immediately reflect updates.
 // A Get or List call soon after an Update or Status.Update call may not reflect the latest object.
 // See https://github.com/kubernetes-sigs/controller-runtime/issues/1622.
 // We use the number of transitions to confirm our cached version is more recent than the reconciler cache.
 // When reconciling an AppWrapper, we proactively detect and abort on conflicts.
 // To defend against bugs in the cache implementation and egregious AppWrapper edits,
-// we eventually give up on persistent conflicts and remove the AppWrapper phase from the cache.
+// we eventually give up on persistent conflicts and remove the AppWrapper from the cache.
 
 // TODO garbage collection
 
 // Cached AppWrapper
 type CachedAppWrapper struct {
-	// AppWrapper phase
-	Phase mcadv1beta1.AppWrapperPhase
+	// AppWrapper state
+	State mcadv1beta1.AppWrapperState
 
 	// AppWrapper step
 	Step mcadv1beta1.AppWrapperStep
@@ -51,21 +51,21 @@ type CachedAppWrapper struct {
 }
 
 // Add AppWrapper to cache
-func (r *AppWrapperReconciler) addCachedPhase(appWrapper *mcadv1beta1.AppWrapper) {
-	r.Cache[appWrapper.UID] = &CachedAppWrapper{Phase: appWrapper.Status.Phase, Step: appWrapper.Status.Step, TransitionCount: appWrapper.Status.TransitionCount}
+func (r *AppWrapperReconciler) addCachedAW(appWrapper *mcadv1beta1.AppWrapper) {
+	r.Cache[appWrapper.UID] = &CachedAppWrapper{State: appWrapper.Status.State, Step: appWrapper.Status.Step, TransitionCount: appWrapper.Status.TransitionCount}
 }
 
 // Remove AppWrapper from cache
-func (r *AppWrapperReconciler) deleteCachedPhase(appWrapper *mcadv1beta1.AppWrapper) {
+func (r *AppWrapperReconciler) deleteCachedAW(appWrapper *mcadv1beta1.AppWrapper) {
 	delete(r.Cache, appWrapper.UID)
 }
 
-// Get AppWrapper phase from cache if available or from AppWrapper if not
-func (r *AppWrapperReconciler) getCachedPhase(appWrapper *mcadv1beta1.AppWrapper) (mcadv1beta1.AppWrapperPhase, mcadv1beta1.AppWrapperStep) {
+// Get AppWrapper from cache if available or from AppWrapper if not
+func (r *AppWrapperReconciler) getCachedAW(appWrapper *mcadv1beta1.AppWrapper) (mcadv1beta1.AppWrapperState, mcadv1beta1.AppWrapperStep) {
 	if cached, ok := r.Cache[appWrapper.UID]; ok && cached.TransitionCount > appWrapper.Status.TransitionCount {
-		return cached.Phase, cached.Step // our cache is more up-to-date than the reconciler cache
+		return cached.State, cached.Step // our cache is more up-to-date than the reconciler cache
 	}
-	return appWrapper.Status.Phase, appWrapper.Status.Step
+	return appWrapper.Status.State, appWrapper.Status.Step
 }
 
 // Check whether reconciler cache and our cache appear to be in sync
@@ -75,7 +75,7 @@ func (r *AppWrapperReconciler) isStale(ctx context.Context, appWrapper *mcadv1be
 		// check number of transitions
 		if cached.TransitionCount < status.TransitionCount {
 			// our cache is behind, update our cache, this is ok
-			r.Cache[appWrapper.UID] = &CachedAppWrapper{Phase: status.Phase, TransitionCount: status.TransitionCount}
+			r.Cache[appWrapper.UID] = &CachedAppWrapper{State: status.State, TransitionCount: status.TransitionCount}
 			cached.Conflict = nil // clear conflict timestamp
 			return false
 		}
@@ -94,7 +94,7 @@ func (r *AppWrapperReconciler) isStale(ctx context.Context, appWrapper *mcadv1be
 			}
 			return true
 		}
-		if cached.Phase != status.Phase || cached.Step != status.Step {
+		if cached.State != status.State || cached.Step != status.Step {
 			// assume something is wrong with our cache
 			delete(r.Cache, appWrapper.UID)
 			log.FromContext(ctx).Error(errors.New("cache conflict"), "Internal error")

--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -147,10 +147,10 @@ func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Wei
 	appWrapperCount := map[stateStepPriority]int{}
 
 	for _, appWrapper := range appWrappers.Items {
-		// get phase from cache if available as reconciler cache may be lagging
-		phase, step := r.getCachedPhase(&appWrapper)
+		// get AppWrapper from cache if available as reconciler cache may be lagging
+		state, step := r.getCachedAW(&appWrapper)
 		priority := int(appWrapper.Spec.Priority)
-		key := stateStepPriority{phase, step, priority}
+		key := stateStepPriority{state, step, priority}
 		if _, exists := appWrapperCount[key]; !exists {
 			appWrapperCount[key] = 0
 		}
@@ -176,7 +176,7 @@ func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Wei
 			// compute max
 			awRequest.Max(podRequest)
 			requests[int(appWrapper.Spec.Priority)].Add(awRequest)
-		} else if phase == mcadv1beta1.Queued &&
+		} else if state == mcadv1beta1.Queued &&
 			time.Now().After(appWrapper.Status.RequeueTimestamp.Add(time.Duration(appWrapper.Spec.Scheduling.Requeuing.PauseTimeInSeconds)*time.Second)) {
 			// add AppWrapper to queue
 			copy := appWrapper // must copy appWrapper before taking a reference, shallow copy ok

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -23,7 +23,7 @@ import (
 )
 
 type stateStepPriority struct {
-	state    mcadv1beta1.AppWrapperPhase
+	state    mcadv1beta1.AppWrapperState
 	step     mcadv1beta1.AppWrapperStep
 	priority int
 }


### PR DESCRIPTION
This PR aligns the go type and field names from `Phase` to `State` to match the serialized name `state`.