### PR TITLE
Add golangci-lint precommit hook

### DIFF
--- a/.github/workflows/mcad-CI.yml
+++ b/.github/workflows/mcad-CI.yml
@@ -31,6 +31,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
 
+    - name: Setup golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+
     - name: Run pre-commit checks
       uses: pre-commit/action@v3.0.0
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,14 @@ issues:
   # restore some of the defaults
   # (fill in the rest as needed)
   exclude-rules:
+  - path: "test/*"
+    linters:
+    - goconst
+    - lll
+    - prealloc
+    - staticcheck
+    - unparam
+    - unused
   - path: "api/*"
     linters:
     - lll

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
   - id: go-fmt
   - id: go-mod-tidy
+  - id: golangci-lint
 - repo: https://github.com/google/yamlfmt
   rev: v0.10.0
   hooks:


### PR DESCRIPTION
This PR adds a `golangci-lint` as a precommit hook.

For now, a number of linters are disabled on the `test` folder because they fail. We should revisit this list in a separate PR to decide which excludes are legitimate.