### PR TITLE
consolidate identical test pairs

### DIFF
--- a/test/e2e/aw_fixtures.go
+++ b/test/e2e/aw_fixtures.go
@@ -261,75 +261,6 @@ func createDeploymentAW(ctx context.Context, name string) *arbv1.AppWrapper {
 	return aw
 }
 
-func createGenericDeploymentAW(ctx context.Context, name string) *arbv1.AppWrapper {
-	rb := []byte(`{"apiVersion": "apps/v1",
-		"kind": "Deployment",
-	"metadata": {
-		"name": "aw-generic-deployment-3",
-		"namespace": "test",
-		"labels": {
-			"app": "aw-generic-deployment-3"
-		}
-	},
-	"spec": {
-		"replicas": 3,
-		"selector": {
-			"matchLabels": {
-				"app": "aw-generic-deployment-3"
-			}
-		},
-		"template": {
-			"metadata": {
-				"labels": {
-					"app": "aw-generic-deployment-3"
-				}
-			},
-			"spec": {
-				"containers": [
-					{
-						"name": "aw-generic-deployment-3",
-						"image": "quay.io/project-codeflare/echo-server:1.0",
-						"ports": [
-							{
-								"containerPort": 80
-							}
-						]
-					}
-				]
-			}
-		}
-	}} `)
-	var schedSpecMin int32 = 3
-
-	aw := &arbv1.AppWrapper{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-		},
-		Spec: arbv1.AppWrapperSpec{
-			Scheduling: arbv1.SchedulingSpec{
-				MinAvailable: schedSpecMin,
-			},
-			Resources: arbv1.AppWrapperResources{
-				GenericItems: []arbv1.GenericItem{
-					{
-						NotImplemented_Replicas: 1,
-						GenericTemplate: runtime.RawExtension{
-							Raw: rb,
-						},
-						CompletionStatus: "Progressing",
-					},
-				},
-			},
-		},
-	}
-
-	err := getClient(ctx).Create(ctx, aw)
-	Expect(err).NotTo(HaveOccurred())
-
-	return aw
-}
-
 func createGenericJobAWWithStatus(ctx context.Context, name string) *arbv1.AppWrapper {
 	rb := []byte(`{
 		"apiVersion": "batch/v1",
@@ -1135,75 +1066,7 @@ func createStatefulSetAW(ctx context.Context, name string) *arbv1.AppWrapper {
 	return aw
 }
 
-func createGenericStatefulSetAW(ctx context.Context, name string) *arbv1.AppWrapper {
-	rb := []byte(`{"apiVersion": "apps/v1",
-		"kind": "StatefulSet",
-	"metadata": {
-		"name": "aw-generic-statefulset-2",
-		"namespace": "test",
-		"labels": {
-			"app": "aw-generic-statefulset-2"
-		}
-	},
-	"spec": {
-		"replicas": 2,
-		"selector": {
-			"matchLabels": {
-				"app": "aw-generic-statefulset-2"
-			}
-		},
-		"template": {
-			"metadata": {
-				"labels": {
-					"app": "aw-generic-statefulset-2"
-				}
-			},
-			"spec": {
-				"containers": [
-					{
-						"name": "aw-generic-statefulset-2",
-						"image": "quay.io/project-codeflare/echo-server:1.0",
-						"imagePullPolicy": "Never",
-						"ports": [
-							{
-								"containerPort": 80
-							}
-						]
-					}
-				]
-			}
-		}
-	}} `)
-	var schedSpecMin int32 = 2
-
-	aw := &arbv1.AppWrapper{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-		},
-		Spec: arbv1.AppWrapperSpec{
-			Scheduling: arbv1.SchedulingSpec{
-				MinAvailable: schedSpecMin,
-			},
-			Resources: arbv1.AppWrapperResources{
-				GenericItems: []arbv1.GenericItem{
-					{
-						NotImplemented_Replicas: 2,
-						GenericTemplate: runtime.RawExtension{
-							Raw: rb,
-						},
-					},
-				},
-			},
-		},
-	}
-	err := getClient(ctx).Create(ctx, aw)
-	Expect(err).NotTo(HaveOccurred())
-
-	return aw
-}
-
-func createBadPodTemplateAW(ctx context.Context, name string) *arbv1.AppWrapper {
+func createBadPodAW(ctx context.Context, name string) *arbv1.AppWrapper {
 	rb := []byte(`{"apiVersion": "v1",
 		"kind": "Pod",
 		"metadata": {
@@ -1573,58 +1436,6 @@ func createGenericPodTooBigAW(ctx context.Context, name string) *arbv1.AppWrappe
 			Name:      name,
 			Namespace: testNamespace,
 			Labels:    labels,
-		},
-		Spec: arbv1.AppWrapperSpec{
-			Scheduling: arbv1.SchedulingSpec{
-				MinAvailable: schedSpecMin,
-			},
-			Resources: arbv1.AppWrapperResources{
-				GenericItems: []arbv1.GenericItem{
-					{
-						GenericTemplate: runtime.RawExtension{
-							Raw: rb,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err := getClient(ctx).Create(ctx, aw)
-	Expect(err).NotTo(HaveOccurred())
-
-	return aw
-}
-
-func createBadGenericPodAW(ctx context.Context, name string) *arbv1.AppWrapper {
-	rb := []byte(`{
-		"apiVersion": "v1",
-		"kind": "Pod",
-		"metadata": {
-			"labels": {
-				"app": "aw-bad-generic-pod-1"
-			}
-		},
-		"spec": {
-			"containers": [
-				{
-					"name": "aw-bad-generic-pod-1",
-					"image": "quay.io/project-codeflare/echo-server:1.0",
-					"ports": [
-						{
-							"containerPort": 80
-						}
-					]
-				}
-			]
-		}
-	} `)
-	var schedSpecMin int32 = 1
-
-	aw := &arbv1.AppWrapper{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
 		},
 		Spec: arbv1.AppWrapperSpec{
 			Scheduling: arbv1.SchedulingSpec{

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -142,15 +142,6 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Create AppWrapper - Generic StatefulSet Only - 2 Pods", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Generic StatefulSet Only - 2 Pods - Started.\n")
-
-			aw := createGenericStatefulSetAW(ctx, "aw-generic-statefulset-2")
-			appwrappers = append(appwrappers, aw)
-			err := waitAWPodsReady(ctx, aw)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		It("Create AppWrapper - Deployment Only - 3 Pods", func() {
 			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Deployment Only 3 Pods - Started.\n")
 
@@ -160,28 +151,19 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Create AppWrapper - Generic Deployment Only - 3 pods", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Generic Deployment Only - 3 pods - Started.\n")
+		It("Create AppWrapper  - Pod Only - 1 Pod", func() {
+			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Pod Only - 1 Pod - Started.\n")
 
-			aw := createGenericDeploymentAW(ctx, "aw-generic-deployment-3")
+			aw := createGenericPodAW(ctx, "aw-pod-1")
 			appwrappers = append(appwrappers, aw)
 			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Create AppWrapper  - PodTemplate Only - 2 Pods", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - PodTemplate Only - 2 Pods - Started.\n")
+		It("Create AppWrapper  - PodTemplates Only - 2 Pods", func() {
+			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - PodTemplate Only - 2 Pods - Started.\n")
 
 			aw := createPodTemplateAW(ctx, "aw-podtemplate-2")
-			appwrappers = append(appwrappers, aw)
-			err := waitAWPodsReady(ctx, aw)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Create AppWrapper  - Generic Pod Only - 1 Pod", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Generic Pod Only - 1 Pod - Started.\n")
-
-			aw := createGenericPodAW(ctx, "aw-generic-pod-1")
 			appwrappers = append(appwrappers, aw)
 			err := waitAWPodsReady(ctx, aw)
 			Expect(err).NotTo(HaveOccurred())
@@ -204,33 +186,23 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 
 	Describe("Handling Invalid Resources", func() {
 
-		It("Create AppWrapper- Bad PodTemplate", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper- Bad PodTemplate - Started.\n")
+		It("Create AppWrapper- Bad Pod", func() {
+			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Bad Pod - Started.\n")
 
-			aw := createBadPodTemplateAW(ctx, "aw-bad-podtemplate-2")
+			aw := createBadPodAW(ctx, "aw-bad-podtemplate-2")
 			appwrappers = append(appwrappers, aw)
 			err := waitAWPodsExists(ctx, aw, 30*time.Second)
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("Create AppWrapper  - Bad Generic PodTemplate Only", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Bad Generic PodTemplate Only - Started.\n")
+		It("Create AppWrapper  - Bad PodTemplate Only", func() {
+			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper - Bad PodTemplate Only - Started.\n")
 
 			aw, err := createBadGenericPodTemplateAW(ctx, "aw-generic-podtemplate-2")
 			if err == nil {
 				appwrappers = append(appwrappers, aw)
 			}
 			Expect(err).To(HaveOccurred())
-		})
-
-		It("Create AppWrapper  - Bad Generic Pod Only", func() {
-			fmt.Fprintf(os.Stdout, "[e2e] Create AppWrapper  - Bad Generic Pod Only - Started.\n")
-
-			aw := createBadGenericPodAW(ctx, "aw-bad-generic-pod-1")
-			appwrappers = append(appwrappers, aw)
-			err := waitAWPodsCompleted(ctx, aw, 10*time.Second)
-			Expect(err).To(HaveOccurred())
-
 		})
 
 		It("Create AppWrapper  - Bad Generic Item Only", func() {
@@ -240,7 +212,6 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 			appwrappers = append(appwrappers, aw)
 			err := waitAWPodsCompleted(ctx, aw, 10*time.Second)
 			Expect(err).To(HaveOccurred())
-
 		})
 	})
 


### PR DESCRIPTION
In mcad V2 there is no difference between "generic" and "non-generic" resources; merge three pairs of tests that were effectively identical.
