### PR TITLE
Improve asymptotic complexity of dispatch loop

### DIFF
--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -220,7 +220,8 @@ func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Wei
 }
 
 // Find next AppWrapper to dispatch in queue order
-func (r *AppWrapperReconciler) selectForDispatch(ctx context.Context) (*mcadv1beta1.AppWrapper, error) {
+func (r *AppWrapperReconciler) selectForDispatch(ctx context.Context) ([]*mcadv1beta1.AppWrapper, error) {
+	selected := []*mcadv1beta1.AppWrapper{}
 	expired := time.Now().After(r.NextSync)
 	if expired {
 		capacity, err := r.computeCapacity(ctx)
@@ -254,12 +255,17 @@ func (r *AppWrapperReconciler) selectForDispatch(ctx context.Context) (*mcadv1be
 		}
 		mcadLog.Info("Queue", "queue", pretty)
 	}
-	// return first AppWrapper that fits if any
+	// return ordered slice of AppWrappers that fit (may be empty)
 	for _, appWrapper := range queue {
 		request := aggregateRequests(appWrapper)
 		fits, gaps := request.Fits(available[int(appWrapper.Spec.Priority)])
 		if fits {
-			return appWrapper.DeepCopy(), nil // deep copy AppWrapper
+			selected = append(selected, appWrapper.DeepCopy()) // deep copy AppWrapper
+			for priority, avail := range available {
+				if priority <= int(appWrapper.Spec.Priority) {
+					avail.Sub(request)
+				}
+			}
 		} else {
 			msg := ""
 			for _, resource := range gaps {
@@ -269,8 +275,7 @@ func (r *AppWrapperReconciler) selectForDispatch(ctx context.Context) (*mcadv1be
 			r.Decisions[appWrapper.UID] = &QueuingDecision{reason: mcadv1beta1.QueuedInsufficientResources, message: msg}
 		}
 	}
-	// no queued AppWrapper fits
-	return nil, nil
+	return selected, nil
 }
 
 // Aggregate requests


### PR DESCRIPTION
Reduce dispatching complexity from O(N^2log(N)) to O(Nlog(N)) by restructuring loops so that the state of the system is only computed from scratch once per dispatch cycle.
