### PR TITLE
Fix golangci-lint inconsistencies

### DIFF
--- a/.github/workflows/mcad-CI.yml
+++ b/.github/workflows/mcad-CI.yml
@@ -31,10 +31,6 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
 
-    - name: Setup golangci-lint
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-
     - name: Run pre-commit checks
       uses: pre-commit/action@v3.0.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,13 @@ repos:
   hooks:
   - id: go-fmt
   - id: go-mod-tidy
+- repo: local
+  hooks:
   - id: golangci-lint
+    name: golangci-lint
+    entry: make lint-fix
+    language: system
+    pass_filenames: false
 - repo: https://github.com/google/yamlfmt
   rev: v0.10.0
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.55.2
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\


### PR DESCRIPTION


# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
fixes #108 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
1. Changed golangci-lint pre-commit hook to run the version installed by Makefile instead of some random version found in `$PATH`.
2. Updated the installed version of golangci-lint: `v1.54.2` -> `v1.55.2`
3. Removed the redundant `Setup golangci-lint` step from `mcad-CI` since the new definition of the golangci-lint hook installs it on the fly.


BTW, the other golang pre-commit hooks are taken from a repo that is sunset. I would recommend taking these hooks from a different repo which is still maintained.
https://github.com/dnephin/pre-commit-golang/issues/98


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->