### PR TITLE
github action to automate releases

### DIFF
--- a/.github/workflows/mcad-release.yaml
+++ b/.github/workflows/mcad-release.yaml
@@ -1,0 +1,39 @@
+# Actions to take when a release is tagged
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: MCAD-release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'project-codeflare/mcad'
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: validate tag format
+      run: |
+        if [[ ${GITHUB_REF_NAME} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+          echo "Tag format is valid."
+        else
+          echo "Invalid tag format: ${GITHUB_REF_NAME}"
+          exit 1
+        fi
+
+    - name: docker login
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+    - name: Build and Push Images
+      run: |
+        make docker-buildx -e TAG=${GITHUB_REF_NAME} -e quay_repository=quay.io/ibm

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ RELEASE_VER := $(shell git describe --tags --abbrev=0)
 TAG := ${TAG}-${RELEASE_VER}
 
 ifeq ($(strip $(quay_repository)),)
-IMG=mcad-controller:${TAG}
+IMG=mcad:${TAG}
 else
-IMG=${quay_repository}/mcad-controller:${TAG}
+IMG=${quay_repository}/mcad:${TAG}
 endif
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -113,11 +113,11 @@ run-test: build envtest ## Run unit tests.
 .PHONY: run-e2e-existing-images
 run-e2e-existing-images:
 ifeq ($(strip $(quay_repository)),)
-	echo "Running e2e with MCAD local image: mcad-controller ${TAG} IfNotPresent."
-	hack/run-e2e-kind.sh mcad-controller ${TAG} IfNotPresent
+	echo "Running e2e with MCAD local image: mcad ${TAG} IfNotPresent."
+	hack/run-e2e-kind.sh mcad ${TAG} IfNotPresent
 else
-	echo "Running e2e with MCAD registry image image: ${quay_repository}/mcad-controller ${TAG}."
-	hack/run-e2e-kind.sh ${quay_repository}/mcad-controller ${TAG}
+	echo "Running e2e with MCAD registry image image: ${quay_repository}/mcad ${TAG}."
+	hack/run-e2e-kind.sh ${quay_repository}/mcad ${TAG}
 endif
 
 .PHONY: run-e2e
@@ -138,7 +138,7 @@ build: manifests generate fmt vet ## Build manager binary.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: run-test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
 .PHONY: docker-push
@@ -157,13 +157,13 @@ kind-push: ## Push docker image with the manager into a kind cluster
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
-docker-buildx: run-test ## Build and push docker image for the manager for cross-platform support
+docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
+	$(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm project-v3-builder
+	$(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	$(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
 
 ##@ Deployment


### PR DESCRIPTION
+ Add GitHub action to build images and push to quay.io on tags that match the vX.Y.Z format.
+ Make minor adjustments to the Makefile to simplify the GitHub action.
  1. Do not ignore errors from subcommand in `make docker-buildx`
  2. Remove `run-tests` as a prerequisite to `make docker` and `make docker-buildx`
  3. Change image name from `mcad-controller` to `mcad`

