### PR TITLE
Split AppWrapper controller into separate dispatcher and runner

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -148,14 +148,23 @@ const (
 	// Resources are not deployed
 	Idle AppWrapperStep = ""
 
-	// MCAD is in the process of creating the wrapped resources
+	// The MCAD dispatcher is dispatching an appwrapper for execution by the runner
+	Dispatching AppWrapperStep = "dispatching"
+
+	// The MCAD runner has accepted an appwrapper for execution
+	Accepted AppWrapperStep = "accepted"
+
+	// The MCAD runner is in the process of creating the wrapped resources
 	Creating AppWrapperStep = "creating"
 
 	// The wrapped resources have been deployed successfully
 	Created AppWrapperStep = "created"
 
-	// MCAD is in the process of deleting the wrapped resources
+	// The MCAD runner is in the process of deleting the wrapped resources
 	Deleting AppWrapperStep = "deleting"
+
+	//The MCAD runner has returned control of an appwrapper to the dispatcher
+	Returned AppWrapperStep = "returned"
 
 	// Queued because of insufficient available resources
 	QueuedInsufficientResources AppWrapperQueuedReason = "InsufficientResources"

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -233,6 +233,9 @@ type AppWrapperTransition struct {
 	// Reason
 	Reason string `json:"reason,omitempty"`
 
+	// Controller that made the transition
+	Controller string `json:"controller,omitempty"`
+
 	// State entered
 	State AppWrapperState `json:"state"`
 

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -151,6 +151,9 @@ const (
 	// The MCAD dispatcher is dispatching an appwrapper for execution by the runner
 	Dispatching AppWrapperStep = "dispatching"
 
+	// The MCAD runner has accepted an appwrapper for execution
+	Accepting AppWrapperStep = "accepting"
+
 	// The MCAD runner is in the process of creating the wrapped resources
 	Creating AppWrapperStep = "creating"
 

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -151,9 +151,6 @@ const (
 	// The MCAD dispatcher is dispatching an appwrapper for execution by the runner
 	Dispatching AppWrapperStep = "dispatching"
 
-	// The MCAD runner has accepted an appwrapper for execution
-	Accepted AppWrapperStep = "accepted"
-
 	// The MCAD runner is in the process of creating the wrapped resources
 	Creating AppWrapperStep = "creating"
 
@@ -164,7 +161,7 @@ const (
 	Deleting AppWrapperStep = "deleting"
 
 	//The MCAD runner has returned control of an appwrapper to the dispatcher
-	Returned AppWrapperStep = "returned"
+	Deleted AppWrapperStep = "deleted"
 
 	// Queued because of insufficient available resources
 	QueuedInsufficientResources AppWrapperQueuedReason = "InsufficientResources"

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -160,7 +160,7 @@ const (
 	// The MCAD runner is in the process of deleting the wrapped resources
 	Deleting AppWrapperStep = "deleting"
 
-	//The MCAD runner has returned control of an appwrapper to the dispatcher
+	// The MCAD runner has returned control of an appwrapper to the dispatcher
 	Deleted AppWrapperStep = "deleted"
 
 	// Queued because of insufficient available resources

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,6 +110,7 @@ func main() {
 			Scheme:           mgr.GetScheme(),
 			Cache:            map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
 			MultiClusterMode: multicluster,
+			ControllerName:   "Dispatcher",
 		},
 		Decisions: map[types.UID]*controller.QueuingDecision{}, // cache of recent queuing decisions
 		Events:    make(chan event.GenericEvent, 1),            // channel to trigger dispatch,
@@ -124,6 +125,7 @@ func main() {
 			Scheme:           mgr.GetScheme(),
 			Cache:            map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
 			MultiClusterMode: multicluster,
+			ControllerName:   "Runner",
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Runner")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(mcadv1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
@@ -104,14 +103,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.AppWrapperReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Cache:     map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
-		Events:    make(chan event.GenericEvent, 1),             // channel to trigger dispatch
-		Decisions: map[types.UID]*controller.QueuingDecision{},  // cache of recent queuing decisions
+	if err = (&controller.Dispatcher{
+		AppWrapperReconciler: controller.AppWrapperReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+			Cache:  map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+		},
+		Decisions: map[types.UID]*controller.QueuingDecision{}, // cache of recent queuing decisions
+		Events:    make(chan event.GenericEvent, 1),            // channel to trigger dispatch,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "AppWrapper")
+		setupLog.Error(err, "unable to create controller", "controller", "Dispatcher")
+		os.Exit(1)
+	}
+
+	if err = (&controller.Runner{
+		AppWrapperReconciler: controller.AppWrapperReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+			Cache:  map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+		},
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Runner")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ func main() {
 	var probeAddr string
 	var namespace string
 	var name string
+	multicluster := false // TODO: multicluster.  Set this based on the command line flags
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -105,9 +106,10 @@ func main() {
 
 	if err = (&controller.Dispatcher{
 		AppWrapperReconciler: controller.AppWrapperReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Cache:  map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+			Client:           mgr.GetClient(),
+			Scheme:           mgr.GetScheme(),
+			Cache:            map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+			MultiClusterMode: multicluster,
 		},
 		Decisions: map[types.UID]*controller.QueuingDecision{}, // cache of recent queuing decisions
 		Events:    make(chan event.GenericEvent, 1),            // channel to trigger dispatch,
@@ -118,9 +120,10 @@ func main() {
 
 	if err = (&controller.Runner{
 		AppWrapperReconciler: controller.AppWrapperReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
-			Cache:  map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+			Client:           mgr.GetClient(),
+			Scheme:           mgr.GetScheme(),
+			Cache:            map[types.UID]*controller.CachedAppWrapper{}, // AppWrapper cache
+			MultiClusterMode: multicluster,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Runner")

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -692,6 +692,9 @@ spec:
                 items:
                   description: State transition
                   properties:
+                    controller:
+                      description: Controller that made the transition
+                      type: string
                     reason:
                       description: Reason
                       type: string

--- a/docs/state-diagram.md
+++ b/docs/state-diagram.md
@@ -12,12 +12,16 @@ stateDiagram-v2
     qi : Idle
 
     %% Running
+    ri : Running
+    ri : Dispatching
     rc : Running
     rc : Creating
     rcd : Running
     rcd : Created
     rd : Running
     rd : Deleting
+    rf : Running
+    rf : Deleted
 
     %% Succeeded
     si : Completed
@@ -30,30 +34,36 @@ stateDiagram-v2
     fcd : Created
     fd : Failed
     fd : Deleting
+    ff : Failed
+    ff : Deleted
     fi: Failed
     fi : Idle
 
     HappyPath : Happy Path
     state HappyPath  {
         e --> qi
-        qi --> rc
+        qi --> ri
+        ri --> rc
         rc --> rcd
         rcd --> si
         rc --> rd : requeueOrFail
         rcd --> rd : requeueOrFail
-        rd --> qi
+        rd --> rf
+        rf --> qi
     }
     rc --> fc : requeueOrFail
     rc --> fd : requeueOrFail
     rcd --> fcd : requeueOrFail
     rcd --> fd : requeueOrFail
-    fd --> fi
+    fd --> ff
+    ff --> fi
 
     classDef failed fill:pink
     class fi failed
     class fc failed
     class fcd failed
     class fd failed
+    class ff failed
 
     classDef succeeded fill:lightgreen
     class si succeeded

--- a/docs/state-diagram.md
+++ b/docs/state-diagram.md
@@ -12,6 +12,8 @@ stateDiagram-v2
     qi : Idle
 
     %% Running
+    ra : Running
+    ra : Accepting
     ri : Running
     ri : Dispatching
     rc : Running
@@ -42,7 +44,8 @@ stateDiagram-v2
     HappyPath : Happy Path
     state HappyPath  {
         e --> qi
-        qi --> ri
+        qi --> ra
+        ra --> ri
         ri --> rc
         rc --> rcd
         rcd --> si

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -32,8 +32,9 @@ import (
 // AppWrapperReconciler is the super type of Dispatcher and Runner reconcilers
 type AppWrapperReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Cache  map[types.UID]*CachedAppWrapper // cache AppWrapper updates for write/read consistency
+	Scheme           *runtime.Scheme
+	Cache            map[types.UID]*CachedAppWrapper // cache AppWrapper updates for write/read consistency
+	MultiClusterMode bool                            // are we operating in multi-cluster mode
 }
 
 const (

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -18,46 +18,32 @@ package controller
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strconv"
-	"time"
 
-	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	mcadv1beta1 "github.com/project-codeflare/mcad/api/v1beta1"
 )
 
-// AppWrapperReconciler reconciles a AppWrapper object
+// AppWrapperReconciler is the super type of Dispatcher and Runner reconcilers
 type AppWrapperReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
-	Cache              map[types.UID]*CachedAppWrapper // cache AppWrapper updates for write/read consistency
-	Events             chan event.GenericEvent         // event channel to trigger dispatch
-	NextLoggedDispatch time.Time                       // when next to log dispatching decisions
-	Decisions          map[types.UID]*QueuingDecision  // transient log of queuing decisions to enable recording in AppWrapper Status
+	Scheme *runtime.Scheme
+	Cache  map[types.UID]*CachedAppWrapper // cache AppWrapper updates for write/read consistency
 }
 
 const (
-	nameLabel          = "appwrapper.mcad.ibm.com"           // owner name label for wrapped resources
-	namespaceLabel     = "appwrapper.mcad.ibm.com/namespace" // owner namespace label for wrapped resources
-	finalizer          = "workload.codeflare.dev/finalizer"  // finalizer name
-	nvidiaGpu          = "nvidia.com/gpu"                    // GPU resource name
-	specNodeName       = ".spec.nodeName"                    // key to index pods based on node placement
-	DefaultClusterName = "self"                              // default cluster name
+	nameLabel          = "appwrapper.mcad.ibm.com"                     // owner name label for wrapped resources
+	namespaceLabel     = "appwrapper.mcad.ibm.com/namespace"           // owner namespace label for wrapped resources
+	dispatchFinalizer  = "workload.codeflare.dev/finalizer_dispatcher" // finalizer name for dispatcher
+	runnerFinalizer    = "workload.codeflare.dev/finalizer_runner"     // finalizer name for runner
+	nvidiaGpu          = "nvidia.com/gpu"                              // GPU resource name
+	specNodeName       = ".spec.nodeName"                              // key to index pods based on node placement
+	DefaultClusterName = "self"                                        // default cluster name
 )
 
 // Structured logger
@@ -65,229 +51,6 @@ var mcadLog = ctrl.Log.WithName("MCAD")
 
 func withAppWrapper(ctx context.Context, appWrapper *mcadv1beta1.AppWrapper) context.Context {
 	return log.IntoContext(ctx, mcadLog.WithValues("namespace", appWrapper.Namespace, "name", appWrapper.Name, "uid", appWrapper.UID))
-}
-
-// permission to edit appwrappers
-
-//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/finalizers,verbs=update
-
-// permission to edit wrapped resources: pods, services, jobs, podgroups
-
-//+kubebuilder:rbac:groups="",resources=pods;services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=scheduling.sigs.k8s.io,resources=podgroups,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=scheduling.x-k8s.io,resources=podgroups,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=kubeflow.org,resources=pytorchjobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cluster.ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
-
-// permission to view nodes
-
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
-
-// Reconcile one AppWrapper or dispatch queued AppWrappers
-// Normal reconciliations "namespace/name" implement all phase transitions except for Queued->Dispatching
-// Queued->Dispatching transitions happen as part of a special "*/*" reconciliation
-// In a "*/*" reconciliation, we iterate over queued AppWrappers in order, dispatching as many as we can
-//
-//gocyclo:ignore
-func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// req == "*/*", dispatch queued AppWrappers
-	if req.Namespace == "*" && req.Name == "*" {
-		return r.dispatch(ctx)
-	}
-
-	// get deep copy of AppWrapper object in reconciler cache
-	appWrapper := &mcadv1beta1.AppWrapper{}
-	if err := r.Get(ctx, req.NamespacedName, appWrapper); err != nil {
-		r.triggerDispatch()
-		return ctrl.Result{}, nil
-	}
-
-	// append appWrapper ID to logger
-	ctx = withAppWrapper(ctx, appWrapper)
-
-	// abort and requeue reconciliation if reconciler cache is stale
-	if r.isStale(ctx, appWrapper) {
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	// handle deletion
-	if !appWrapper.DeletionTimestamp.IsZero() {
-		// delete wrapped resources
-		if !r.deleteResources(ctx, appWrapper, *appWrapper.DeletionTimestamp) {
-			// requeue reconciliation after delay
-			return ctrl.Result{RequeueAfter: deletionDelay}, nil
-		}
-		// remove finalizer
-		if controllerutil.RemoveFinalizer(appWrapper, finalizer) {
-			if err := r.Update(ctx, appWrapper); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		// remove AppWrapper from cache
-		r.deleteCachedAW(appWrapper)
-		delete(r.Decisions, appWrapper.UID)
-		log.FromContext(ctx).Info("Deleted")
-		return ctrl.Result{}, nil
-	}
-
-	// handle other states
-	switch appWrapper.Status.State {
-	case mcadv1beta1.Empty:
-		// add finalizer
-		if controllerutil.AddFinalizer(appWrapper, finalizer) {
-			if err := r.Update(ctx, appWrapper); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		// set queued/idle status only after adding finalizer
-		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Queued, mcadv1beta1.Idle)
-
-	case mcadv1beta1.Queued:
-		// Propagate most recent queuing decision to AppWrapper's Queued Condition
-		if decision, ok := r.Decisions[appWrapper.UID]; ok {
-			meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
-				Type:    string(mcadv1beta1.Queued),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(decision.reason),
-				Message: decision.message,
-			})
-			if r.Status().Update(ctx, appWrapper) == nil {
-				// If successfully propagated, remove from in memory map
-				delete(r.Decisions, appWrapper.UID)
-			}
-		}
-
-		if meta.FindStatusCondition(appWrapper.Status.Conditions, string(mcadv1beta1.Queued)) == nil {
-			// Absence of Queued Condition strongly suggests AppWrapper is new; trigger dispatch and a short requeue
-			r.triggerDispatch()
-			return ctrl.Result{RequeueAfter: deletionDelay}, nil
-		} else {
-			return ctrl.Result{RequeueAfter: queuedDelay}, nil
-		}
-
-	case mcadv1beta1.Running:
-		switch appWrapper.Status.Step {
-		case mcadv1beta1.Creating:
-			// create wrapped resources
-			if err, fatal := r.createResources(ctx, appWrapper); err != nil {
-				return r.requeueOrFail(ctx, appWrapper, fatal, err.Error())
-			}
-			// set running/created status only after successfully requesting the creation of all resources
-			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Created)
-
-		case mcadv1beta1.Created:
-			// count AppWrapper pods
-			counts, err := r.countPods(ctx, appWrapper)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			// check for successful completion by looking at pods and wrapped resources
-			success, err := r.isSuccessful(ctx, appWrapper, counts)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			// set succeeded/idle status if done
-			if success {
-				r.triggerDispatch()
-				return r.updateStatus(ctx, appWrapper, mcadv1beta1.Succeeded, mcadv1beta1.Idle)
-			}
-			// check pod count if dispatched for a while
-			minAvailable := appWrapper.Spec.Scheduling.MinAvailable
-			if minAvailable == 0 {
-				minAvailable = 1 // default to expecting 1 running pod
-			}
-			if metav1.Now().After(appWrapper.Status.DispatchTimestamp.Add(time.Duration(appWrapper.Spec.Scheduling.Requeuing.TimeInSeconds)*time.Second)) &&
-				counts.Running+counts.Succeeded < int(minAvailable) {
-				customMessage := "expected pods " + strconv.Itoa(int(minAvailable)) + " but found pods " + strconv.Itoa(counts.Running+counts.Succeeded)
-				// requeue or fail if max retries exhausted with custom error message
-				return r.requeueOrFail(ctx, appWrapper, false, customMessage)
-			}
-			// AppWrapper is healthy, requeue reconciliation after delay
-			return ctrl.Result{RequeueAfter: runDelay}, nil
-
-		case mcadv1beta1.Deleting:
-			// delete wrapped resources
-			if !r.deleteResources(ctx, appWrapper, appWrapper.Status.RequeueTimestamp) {
-				// requeue reconciliation after delay
-				return ctrl.Result{RequeueAfter: deletionDelay}, nil
-			}
-			// reset status to queued/idle
-			appWrapper.Status.Restarts += 1
-			appWrapper.Status.RequeueTimestamp = metav1.Now() // overwrite requeue decision time with completion time
-			msg := "Requeued by MCAD"
-			if decision, ok := r.Decisions[appWrapper.UID]; ok && decision.reason == mcadv1beta1.QueuedRequeue {
-				msg = fmt.Sprintf("Requeued because %s", decision.message)
-			}
-			meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
-				Type:    string(mcadv1beta1.Queued),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(mcadv1beta1.QueuedRequeue),
-				Message: msg,
-			})
-			res, err := r.updateStatus(ctx, appWrapper, mcadv1beta1.Queued, mcadv1beta1.Idle)
-			if err == nil {
-				delete(r.Decisions, appWrapper.UID)
-			}
-			return res, err
-		}
-
-	case mcadv1beta1.Failed:
-		switch appWrapper.Status.Step {
-		case mcadv1beta1.Deleting:
-			// delete wrapped resources
-			if !r.deleteResources(ctx, appWrapper, appWrapper.Status.RequeueTimestamp) {
-				// requeue reconciliation after delay
-				return ctrl.Result{RequeueAfter: deletionDelay}, nil
-			}
-			// set status to failed/idle
-			r.triggerDispatch()
-			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Idle)
-		}
-	}
-	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// initialize periodic dispatch invocation
-	r.triggerDispatch()
-	// watch AppWrapper pods, jobs, watch events
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&mcadv1beta1.AppWrapper{}).
-		Watches(&v1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
-		Watches(&batchv1.Job{}, handler.EnqueueRequestsFromMapFunc(r.jobMapFunc)).
-		WatchesRawSource(&source.Channel{Source: r.Events}, &handler.EnqueueRequestForObject{}).
-		Complete(r)
-}
-
-// Map labelled pods to corresponding AppWrappers
-func (r *AppWrapperReconciler) podMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
-	pod := obj.(*v1.Pod)
-	if name, ok := pod.Labels[nameLabel]; ok {
-		if namespace, ok := pod.Labels[namespaceLabel]; ok {
-			if pod.Status.Phase == v1.PodSucceeded {
-				return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
-			}
-		}
-	}
-	return nil
-}
-
-// Map labelled jobs to corresponding AppWrappers
-func (r *AppWrapperReconciler) jobMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
-	job := obj.(*batchv1.Job)
-	if name, ok := job.Labels[nameLabel]; ok {
-		if namespace, ok := job.Labels[namespaceLabel]; ok {
-			if !job.Status.CompletionTime.IsZero() {
-				return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
-			}
-		}
-	}
-	return nil
 }
 
 // Update AppWrapper status
@@ -314,66 +77,4 @@ func (r *AppWrapperReconciler) updateStatus(ctx context.Context, appWrapper *mca
 	r.addCachedAW(appWrapper)
 	log.FromContext(ctx).Info(string(state), "state", state, "step", step)
 	return ctrl.Result{}, nil
-}
-
-// Set requeuing or failed status depending on error, configuration, and restarts count
-func (r *AppWrapperReconciler) requeueOrFail(ctx context.Context, appWrapper *mcadv1beta1.AppWrapper, fatal bool, reason string) (ctrl.Result, error) {
-	if appWrapper.Spec.Scheduling.MinAvailable < 0 {
-		// set failed status and leave resources as is
-		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, appWrapper.Status.Step, reason)
-	} else if fatal || appWrapper.Spec.Scheduling.Requeuing.MaxNumRequeuings > 0 && appWrapper.Status.Restarts >= appWrapper.Spec.Scheduling.Requeuing.MaxNumRequeuings {
-		// set failed/deleting status (request deletion of wrapped resources)
-		appWrapper.Status.RequeueTimestamp = metav1.Now()
-		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Deleting, reason)
-	}
-	// requeue AppWrapper
-	appWrapper.Status.RequeueTimestamp = metav1.Now()
-	r.Decisions[appWrapper.UID] = &QueuingDecision{reason: mcadv1beta1.QueuedRequeue, message: reason}
-	return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Deleting, reason)
-}
-
-// Trigger dispatch by means of "*/*" request
-func (r *AppWrapperReconciler) triggerDispatch() {
-	select {
-	case r.Events <- event.GenericEvent{Object: &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "*", Name: "*"}}}:
-	default:
-		// do not block if event is already in channel
-	}
-}
-
-// Attempt to select and dispatch appWrappers until either capacity is exhausted or no candidates remain
-func (r *AppWrapperReconciler) dispatch(ctx context.Context) (ctrl.Result, error) {
-	// find dispatch candidates according to priorities, precedence, and available resources
-	selectedAppWrappers, err := r.selectForDispatch(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Dispatch one by one until either exhausted candidates or hit an error
-	for _, appWrapper := range selectedAppWrappers {
-		// append appWrapper ID to logger
-		ctx := withAppWrapper(ctx, appWrapper)
-		// abort and requeue reconciliation if reconciler cache is stale
-		if r.isStale(ctx, appWrapper) {
-			return ctrl.Result{Requeue: true}, nil
-		}
-		// check state again to be extra safe
-		if appWrapper.Status.State != mcadv1beta1.Queued {
-			log.FromContext(ctx).Error(errors.New("not queued"), "Internal error")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		// set dispatching time and status
-		appWrapper.Status.DispatchTimestamp = metav1.Now()
-		meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
-			Type:    string(mcadv1beta1.Queued),
-			Status:  metav1.ConditionFalse,
-			Reason:  string(mcadv1beta1.QueuedDispatch),
-			Message: "Selected for dispatch",
-		})
-		if _, err := r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Creating); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	return ctrl.Result{RequeueAfter: dispatchDelay}, nil
 }

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -41,6 +41,7 @@ type AppWrapperReconciler struct {
 	Scheme           *runtime.Scheme
 	Cache            map[types.UID]*CachedAppWrapper // cache AppWrapper updates for write/read consistency
 	MultiClusterMode bool                            // are we operating in multi-cluster mode
+	ControllerName   string                          // name of the controller
 }
 
 const (
@@ -65,7 +66,7 @@ func withAppWrapper(ctx context.Context, appWrapper *mcadv1beta1.AppWrapper) con
 func (r *AppWrapperReconciler) updateStatus(ctx context.Context, appWrapper *mcadv1beta1.AppWrapper, state mcadv1beta1.AppWrapperState, step mcadv1beta1.AppWrapperStep, reason ...string) (ctrl.Result, error) {
 	// log transition
 	now := metav1.Now()
-	transition := mcadv1beta1.AppWrapperTransition{Time: now, State: state, Step: step}
+	transition := mcadv1beta1.AppWrapperTransition{Time: now, Controller: r.ControllerName, State: state, Step: step}
 	if len(reason) > 0 {
 		transition.Reason = reason[0]
 	}

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -29,6 +29,12 @@ import (
 	mcadv1beta1 "github.com/project-codeflare/mcad/api/v1beta1"
 )
 
+// All AppWrapperReconcilers need permission to edit appwrappers
+
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/finalizers,verbs=update
+
 // AppWrapperReconciler is the super type of Dispatcher and Runner reconcilers
 type AppWrapperReconciler struct {
 	client.Client

--- a/internal/controller/cache.go
+++ b/internal/controller/cache.go
@@ -75,7 +75,7 @@ func (r *AppWrapperReconciler) isStale(ctx context.Context, appWrapper *mcadv1be
 		// check number of transitions
 		if cached.TransitionCount < status.TransitionCount {
 			// our cache is behind, update our cache, this is ok
-			r.Cache[appWrapper.UID] = &CachedAppWrapper{State: status.State, TransitionCount: status.TransitionCount}
+			r.Cache[appWrapper.UID] = &CachedAppWrapper{State: status.State, Step: status.Step, TransitionCount: status.TransitionCount}
 			cached.Conflict = nil // clear conflict timestamp
 			return false
 		}

--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -73,7 +73,7 @@ func updateRequestedMetricGeneric(request Weights, priority int, resourceName v1
 // Compute resources reserved by AppWrappers at every priority level for the specified cluster
 // Sort queued AppWrappers in dispatch order
 // AppWrappers in output queue must be cloned if mutated
-func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Weights, []*mcadv1beta1.AppWrapper, error) {
+func (r *Dispatcher) listAppWrappers(ctx context.Context) (map[int]Weights, []*mcadv1beta1.AppWrapper, error) {
 	appWrappers := &mcadv1beta1.AppWrapperList{}
 	if err := r.List(ctx, appWrappers, client.UnsafeDisableDeepCopy); err != nil {
 		return nil, nil, err
@@ -157,7 +157,7 @@ func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Wei
 }
 
 // Find next AppWrapper to dispatch in queue order
-func (r *AppWrapperReconciler) selectForDispatch(ctx context.Context) ([]*mcadv1beta1.AppWrapper, error) {
+func (r *Dispatcher) selectForDispatch(ctx context.Context) ([]*mcadv1beta1.AppWrapper, error) {
 	selected := []*mcadv1beta1.AppWrapper{}
 	logThisDispatch := time.Now().After(r.NextLoggedDispatch)
 	if logThisDispatch {

--- a/internal/controller/dispatcher.go
+++ b/internal/controller/dispatcher.go
@@ -83,7 +83,7 @@ func (r *Dispatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			// TODO: Multicluster. This is where we remove the placement that maps
 			// the appWrapper to the execution cluster. Only after the placement is
 			// successfully removed will we proceed to removing the dispatch finalizer
-			return ctrl.Result{}, fmt.Errorf("Unimplemented multi-cluster synch path")
+			return ctrl.Result{}, fmt.Errorf("unimplemented multi-cluster synch path")
 		} else {
 			// wait for the runner to remove its finalizer before we remove ours
 			if controllerutil.ContainsFinalizer(appWrapper, runnerFinalizer) {
@@ -150,16 +150,16 @@ func (r *Dispatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				// TODO: Multicluster. This is where we create the placement that maps
 				// the appWrapper to the execution cluster. Only if the placement creation is successful
 				// will we do the update of the status to running/creating.
-				return ctrl.Result{}, fmt.Errorf("Unimplemented multi-cluster synch path")
+				return ctrl.Result{}, fmt.Errorf("unimplemented multi-cluster synch path")
 			}
 			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Creating)
 
 		case mcadv1beta1.Deleted:
 			if r.MultiClusterMode {
-				// TODO: Multicluster. This is where we remove the placement that maps
+				// TODO: Multicluster. This is where we delete the placement that maps
 				// the appWrapper to the execution cluster. Only after the placement is
-				// successfully removed will we proceed to resetting the status to queued/idle
-				return ctrl.Result{}, fmt.Errorf("Unimplemented multi-cluster synch path")
+				// completely deleted will we proceed to resetting the status to queued/idle
+				return ctrl.Result{}, fmt.Errorf("unimplemented multi-cluster synch path")
 			}
 
 			// reset status to queued/idle

--- a/internal/controller/dispatcher.go
+++ b/internal/controller/dispatcher.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2023 IBM Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	mcadv1beta1 "github.com/project-codeflare/mcad/api/v1beta1"
+)
+
+// AppWrapperReconciler responsible for the portion of the lifecycle that happens on the scheduling cluster
+type Dispatcher struct {
+	AppWrapperReconciler
+	Decisions          map[types.UID]*QueuingDecision // transient log of queuing decisions to enable recording in AppWrapper Status
+	Events             chan event.GenericEvent        // event channel to trigger dispatch
+	NextLoggedDispatch time.Time                      // when next to log dispatching decisions
+}
+
+// permission to edit appwrappers
+
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/finalizers,verbs=update
+
+// Reconcile one AppWrapper or dispatch queued AppWrappers during the dispatching phases of their lifecycle.
+//
+// Normal reconciliations "namespace/name" implement all phase transitions except for Queued->Dispatching
+// Queued->Dispatching transitions happen as part of a special "*/*" reconciliation
+// In a "*/*" reconciliation, we iterate over queued AppWrappers in order, dispatching as many as we can
+func (r *Dispatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// req == "*/*", dispatch queued AppWrappers
+	if req.Namespace == "*" && req.Name == "*" {
+		return r.dispatch(ctx)
+	}
+
+	// get deep copy of AppWrapper object in reconciler cache
+	appWrapper := &mcadv1beta1.AppWrapper{}
+	if err := r.Get(ctx, req.NamespacedName, appWrapper); err != nil {
+		r.triggerDispatch()
+		return ctrl.Result{}, nil
+	}
+
+	// append appWrapper ID to logger
+	ctx = withAppWrapper(ctx, appWrapper)
+
+	// abort and requeue reconciliation if reconciler cache is stale
+	if r.isStale(ctx, appWrapper) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// handle deletion
+	if !appWrapper.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(appWrapper, runnerFinalizer) {
+			// wait for the runner to remove its finalizer before we remove ours
+			return ctrl.Result{RequeueAfter: deletionDelay}, nil
+		}
+
+		// remove finalizer
+		if controllerutil.RemoveFinalizer(appWrapper, dispatchFinalizer) {
+			if err := r.Update(ctx, appWrapper); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.FromContext(ctx).Info("Deleted dispatcher finalizer")
+		}
+		// remove AppWrapper from cache
+		r.deleteCachedAW(appWrapper)
+		delete(r.Decisions, appWrapper.UID)
+		return ctrl.Result{}, nil
+	}
+
+	// handle other states
+	switch appWrapper.Status.State {
+	case mcadv1beta1.Empty:
+		// add dispatch finalizer
+		if controllerutil.AddFinalizer(appWrapper, dispatchFinalizer) {
+			if err := r.Update(ctx, appWrapper); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		// set queued/idle status only after adding finalizer
+		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Queued, mcadv1beta1.Idle)
+
+	case mcadv1beta1.Queued:
+		// Propagate most recent queuing decision to AppWrapper's Queued Condition
+		if decision, ok := r.Decisions[appWrapper.UID]; ok {
+			meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
+				Type:    string(mcadv1beta1.Queued),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(decision.reason),
+				Message: decision.message,
+			})
+			if r.Status().Update(ctx, appWrapper) == nil {
+				// If successfully propagated, remove from in memory map
+				delete(r.Decisions, appWrapper.UID)
+			}
+		}
+
+		if meta.FindStatusCondition(appWrapper.Status.Conditions, string(mcadv1beta1.Queued)) == nil {
+			// Absence of Queued Condition strongly suggests AppWrapper is new; trigger dispatch and a short requeue
+			r.triggerDispatch()
+			return ctrl.Result{RequeueAfter: deletionDelay}, nil
+		} else {
+			return ctrl.Result{RequeueAfter: queuedDelay}, nil
+		}
+
+	case mcadv1beta1.Running:
+		switch appWrapper.Status.Step {
+		case mcadv1beta1.Dispatching:
+			// In the multi-cluster version this is where we synch the appWrapper to the execution cluster
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Accepted)
+
+		case mcadv1beta1.Returned:
+			// In the multi-cluster version this is where we unsynch appWrapper
+
+			// reset status to queued/idle
+			appWrapper.Status.Restarts += 1
+			appWrapper.Status.RequeueTimestamp = metav1.Now() // overwrite requeue decision time with completion time
+			msg := "Requeued by MCAD"
+			if decision, ok := r.Decisions[appWrapper.UID]; ok && decision.reason == mcadv1beta1.QueuedRequeue {
+				msg = fmt.Sprintf("Requeued because %s", decision.message)
+			}
+			meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
+				Type:    string(mcadv1beta1.Queued),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(mcadv1beta1.QueuedRequeue),
+				Message: msg,
+			})
+			res, err := r.updateStatus(ctx, appWrapper, mcadv1beta1.Queued, mcadv1beta1.Idle)
+			if err == nil {
+				delete(r.Decisions, appWrapper.UID)
+				r.triggerDispatch()
+			}
+			return res, err
+		}
+
+	case mcadv1beta1.Succeeded:
+		switch appWrapper.Status.Step {
+		case mcadv1beta1.Returned:
+			// In the multi-cluster version this is where we unsynch appWrapper
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Succeeded, mcadv1beta1.Idle)
+		case mcadv1beta1.Idle:
+			r.triggerDispatch()
+			return ctrl.Result{}, nil
+		}
+
+	case mcadv1beta1.Failed:
+		switch appWrapper.Status.Step {
+		case mcadv1beta1.Returned:
+			// In the multi-cluster version this is where we unsynch appWrapper
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Idle)
+		case mcadv1beta1.Idle:
+			r.triggerDispatch()
+			return ctrl.Result{}, nil
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Dispatcher) SetupWithManager(mgr ctrl.Manager) error {
+	// initialize periodic dispatch invocation
+	r.triggerDispatch()
+	// watch AppWrappers and dispatch events
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mcadv1beta1.AppWrapper{}).
+		WatchesRawSource(&source.Channel{Source: r.Events}, &handler.EnqueueRequestForObject{}).
+		Complete(r)
+}
+
+// Trigger dispatch by means of "*/*" request
+func (r *Dispatcher) triggerDispatch() {
+	select {
+	case r.Events <- event.GenericEvent{Object: &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: "*", Name: "*"}}}:
+	default:
+		// do not block if event is already in channel
+	}
+}
+
+// Attempt to select and dispatch appWrappers until either capacity is exhausted or no candidates remain
+func (r *Dispatcher) dispatch(ctx context.Context) (ctrl.Result, error) {
+	// find dispatch candidates according to priorities, precedence, and available resources
+	selectedAppWrappers, err := r.selectForDispatch(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Dispatch one by one until either exhausted candidates or hit an error
+	for _, appWrapper := range selectedAppWrappers {
+		// append appWrapper ID to logger
+		ctx := withAppWrapper(ctx, appWrapper)
+		// abort and requeue reconciliation if reconciler cache is stale
+		if r.isStale(ctx, appWrapper) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		// check state again to be extra safe
+		if appWrapper.Status.State != mcadv1beta1.Queued {
+			log.FromContext(ctx).Error(errors.New("not queued"), "Internal error")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		// set dispatching time and status
+		appWrapper.Status.DispatchTimestamp = metav1.Now()
+		meta.SetStatusCondition(&appWrapper.Status.Conditions, metav1.Condition{
+			Type:    string(mcadv1beta1.Queued),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(mcadv1beta1.QueuedDispatch),
+			Message: "Selected for dispatch",
+		})
+		if _, err := r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Dispatching); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{RequeueAfter: dispatchDelay}, nil
+}

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -99,7 +99,7 @@ func (r *Runner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 	case mcadv1beta1.Running:
 		switch appWrapper.Status.Step {
 
-		case mcadv1beta1.Creating:
+		case mcadv1beta1.Accepting:
 			if r.MultiClusterMode {
 				// add runner finalizer to this copy of the object
 				if controllerutil.AddFinalizer(appWrapper, runnerFinalizer) {
@@ -108,7 +108,11 @@ func (r *Runner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 					}
 				}
 			}
+			// set dispatching time
+			appWrapper.Status.DispatchTimestamp = metav1.Now()
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Creating)
 
+		case mcadv1beta1.Creating:
 			// create wrapped resources
 			if err, fatal := r.createResources(ctx, appWrapper); err != nil {
 				return r.requeueOrFail(ctx, appWrapper, fatal, err.Error())

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -98,14 +98,14 @@ func (r *Runner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 		return ctrl.Result{}, nil
 	}
 
-	// handle state transitions that occur on the executing cluster
+	// handle state transitions that occur on the execution cluster
 	switch appWrapper.Status.State {
 	case mcadv1beta1.Running:
 		switch appWrapper.Status.Step {
 
 		case mcadv1beta1.Creating:
 			if r.MultiClusterMode {
-				// add runner finalizer to this copy of the object (finalizers not downsynched)
+				// add runner finalizer to this copy of the object
 				if controllerutil.AddFinalizer(appWrapper, runnerFinalizer) {
 					if err := r.Update(ctx, appWrapper); err != nil {
 						return ctrl.Result{}, err
@@ -166,7 +166,7 @@ func (r *Runner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 				// requeue reconciliation after delay
 				return ctrl.Result{RequeueAfter: deletionDelay}, nil
 			}
-			// set status to failed/returned
+			// set status to failed/deleted
 			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Deleted)
 		}
 	}
@@ -184,7 +184,7 @@ func (r *AppWrapperReconciler) requeueOrFail(ctx context.Context, appWrapper *mc
 		appWrapper.Status.RequeueTimestamp = metav1.Now()
 		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Deleting, reason)
 	}
-	// requeue AppWrapper
+	// start process of requeueing AppWrapper by requesting the deletion of wrapped resources
 	appWrapper.Status.RequeueTimestamp = metav1.Now()
 	return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Deleting, reason)
 }

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 IBM Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcadv1beta1 "github.com/project-codeflare/mcad/api/v1beta1"
+)
+
+// AppWrapperReconciler responsible for the portion of the lifecycle that happens on the execution cluster
+type Runner struct {
+	AppWrapperReconciler
+}
+
+// permission to edit appwrappers
+
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers/finalizers,verbs=update
+
+// permission to edit wrapped resources: pods, services, jobs, podgroups
+
+//+kubebuilder:rbac:groups="",resources=pods;services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=scheduling.sigs.k8s.io,resources=podgroups,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=scheduling.x-k8s.io,resources=podgroups,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kubeflow.org,resources=pytorchjobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
+
+// permission to view nodes
+
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+
+// Reconcile one Running AppWrapper on an execution cluster and monitor health of its execution resources.
+func (r *Runner) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// get deep copy of AppWrapper object in reconciler cache
+	appWrapper := &mcadv1beta1.AppWrapper{}
+	if err := r.Get(ctx, req.NamespacedName, appWrapper); err != nil {
+		// no such AppWrapper, nothing to reconcile, not an error
+		return ctrl.Result{}, nil
+	}
+
+	// append appWrapper ID to logger
+	ctx = withAppWrapper(ctx, appWrapper)
+
+	// abort and requeue reconciliation if reconciler cache is stale
+	if r.isStale(ctx, appWrapper) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// handle deletion
+	if !appWrapper.DeletionTimestamp.IsZero() {
+		// delete wrapped resources
+		if !r.deleteResources(ctx, appWrapper, *appWrapper.DeletionTimestamp) {
+			// requeue reconciliation after delay
+			return ctrl.Result{RequeueAfter: deletionDelay}, nil
+		}
+		// remove finalizer
+		if controllerutil.RemoveFinalizer(appWrapper, runnerFinalizer) {
+			if err := r.Update(ctx, appWrapper); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.FromContext(ctx).Info("Deleted runner finalizer")
+		}
+		// remove AppWrapper from cache
+		r.deleteCachedAW(appWrapper)
+		return ctrl.Result{}, nil
+	}
+
+	// handle state transitions that occur on the executing cluster
+	switch appWrapper.Status.State {
+	case mcadv1beta1.Running:
+		switch appWrapper.Status.Step {
+		case mcadv1beta1.Accepted:
+			// add runner finalizer
+			if controllerutil.AddFinalizer(appWrapper, runnerFinalizer) {
+				if err := r.Update(ctx, appWrapper); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			// set running/creating status only after successfully adding the finalizer
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Creating)
+		case mcadv1beta1.Creating:
+			// add runner finalizer
+			if controllerutil.AddFinalizer(appWrapper, runnerFinalizer) {
+				if err := r.Update(ctx, appWrapper); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+			// create wrapped resources
+			if err, fatal := r.createResources(ctx, appWrapper); err != nil {
+				return r.requeueOrFail(ctx, appWrapper, fatal, err.Error())
+			}
+			// set running/created status only after successfully requesting the creation of all resources
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Created)
+
+		case mcadv1beta1.Created:
+			// count AppWrapper pods
+			counts, err := r.countPods(ctx, appWrapper)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			// check for successful completion by looking at pods and wrapped resources
+			success, err := r.isSuccessful(ctx, appWrapper, counts)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			// set succeeded/returned status if done
+			if success {
+				return r.updateStatus(ctx, appWrapper, mcadv1beta1.Succeeded, mcadv1beta1.Returned)
+			}
+			// check pod count if dispatched for a while
+			minAvailable := appWrapper.Spec.Scheduling.MinAvailable
+			if minAvailable == 0 {
+				minAvailable = 1 // default to expecting 1 running pod
+			}
+			if metav1.Now().After(appWrapper.Status.DispatchTimestamp.Add(time.Duration(appWrapper.Spec.Scheduling.Requeuing.TimeInSeconds)*time.Second)) &&
+				counts.Running+counts.Succeeded < int(minAvailable) {
+				customMessage := "expected pods " + strconv.Itoa(int(minAvailable)) + " but found pods " + strconv.Itoa(counts.Running+counts.Succeeded)
+				// requeue or fail if max retries exhausted with custom error message
+				return r.requeueOrFail(ctx, appWrapper, false, customMessage)
+			}
+			// AppWrapper is healthy, requeue reconciliation after delay
+			return ctrl.Result{RequeueAfter: runDelay}, nil
+
+		case mcadv1beta1.Deleting:
+			// delete wrapped resources
+			if !r.deleteResources(ctx, appWrapper, appWrapper.Status.RequeueTimestamp) {
+				// requeue reconciliation after delay
+				return ctrl.Result{RequeueAfter: deletionDelay}, nil
+			}
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Returned)
+		}
+
+	case mcadv1beta1.Failed:
+		switch appWrapper.Status.Step {
+		case mcadv1beta1.Deleting:
+			// delete wrapped resources
+			if !r.deleteResources(ctx, appWrapper, appWrapper.Status.RequeueTimestamp) {
+				// requeue reconciliation after delay
+				return ctrl.Result{RequeueAfter: deletionDelay}, nil
+			}
+			// set status to failed/returned
+			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Returned)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// Set requeuing or failed status depending on error, configuration, and restarts count
+func (r *AppWrapperReconciler) requeueOrFail(ctx context.Context, appWrapper *mcadv1beta1.AppWrapper, fatal bool, reason string) (ctrl.Result, error) {
+	if appWrapper.Spec.Scheduling.MinAvailable < 0 {
+		// set failed status and leave resources as is
+		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, appWrapper.Status.Step, reason)
+	} else if fatal || appWrapper.Spec.Scheduling.Requeuing.MaxNumRequeuings > 0 && appWrapper.Status.Restarts >= appWrapper.Spec.Scheduling.Requeuing.MaxNumRequeuings {
+		// set failed/deleting status (request deletion of wrapped resources)
+		appWrapper.Status.RequeueTimestamp = metav1.Now()
+		return r.updateStatus(ctx, appWrapper, mcadv1beta1.Failed, mcadv1beta1.Deleting, reason)
+	}
+	// requeue AppWrapper
+	appWrapper.Status.RequeueTimestamp = metav1.Now()
+	return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Deleting, reason)
+}
+
+// Map labelled pods to corresponding AppWrappers
+func (r *Runner) podMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod := obj.(*v1.Pod)
+	if name, ok := pod.Labels[nameLabel]; ok {
+		if namespace, ok := pod.Labels[namespaceLabel]; ok {
+			if pod.Status.Phase == v1.PodSucceeded {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
+			}
+		}
+	}
+	return nil
+}
+
+// Map labelled jobs to corresponding AppWrappers
+func (r *Runner) jobMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
+	job := obj.(*batchv1.Job)
+	if name, ok := job.Labels[nameLabel]; ok {
+		if namespace, ok := job.Labels[namespaceLabel]; ok {
+			if !job.Status.CompletionTime.IsZero() {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}}
+			}
+		}
+	}
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Runner) SetupWithManager(mgr ctrl.Manager) error {
+	// watch AppWrappers, pods, jobs
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mcadv1beta1.AppWrapper{}).
+		Watches(&v1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
+		Watches(&batchv1.Job{}, handler.EnqueueRequestsFromMapFunc(r.jobMapFunc)).
+		Complete(r)
+}

--- a/test/e2e-kuttl-acct/steps/01-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/01-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl-acct/steps/01-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/01-assert.yaml
@@ -9,8 +9,6 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl-acct/steps/01-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/01-assert.yaml
@@ -7,6 +7,10 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl-acct/steps/02-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/02-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl-acct/steps/02-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/02-assert.yaml
@@ -9,8 +9,6 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl-acct/steps/02-assert.yaml
+++ b/test/e2e-kuttl-acct/steps/02-assert.yaml
@@ -7,6 +7,10 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/01-assert.yaml
+++ b/test/e2e-kuttl/steps/01-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/01-assert.yaml
+++ b/test/e2e-kuttl/steps/01-assert.yaml
@@ -9,8 +9,6 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/01-assert.yaml
+++ b/test/e2e-kuttl/steps/01-assert.yaml
@@ -7,6 +7,10 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/02-assert.yaml
+++ b/test/e2e-kuttl/steps/02-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/02-assert.yaml
+++ b/test/e2e-kuttl/steps/02-assert.yaml
@@ -9,8 +9,6 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/02-assert.yaml
+++ b/test/e2e-kuttl/steps/02-assert.yaml
@@ -7,6 +7,10 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/03-assert.yaml
+++ b/test/e2e-kuttl/steps/03-assert.yaml
@@ -9,12 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created
-  - state: Completed
-    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/03-assert.yaml
+++ b/test/e2e-kuttl/steps/03-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/03-assert.yaml
+++ b/test/e2e-kuttl/steps/03-assert.yaml
@@ -7,8 +7,14 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created
+  - state: Completed
+    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/04-assert.yaml
+++ b/test/e2e-kuttl/steps/04-assert.yaml
@@ -9,12 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created
-  - state: Completed
-    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/04-assert.yaml
+++ b/test/e2e-kuttl/steps/04-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/04-assert.yaml
+++ b/test/e2e-kuttl/steps/04-assert.yaml
@@ -7,8 +7,14 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created
+  - state: Completed
+    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/06-assert.yaml
+++ b/test/e2e-kuttl/steps/06-assert.yaml
@@ -9,12 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created
-  - state: Completed
-    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/06-assert.yaml
+++ b/test/e2e-kuttl/steps/06-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/06-assert.yaml
+++ b/test/e2e-kuttl/steps/06-assert.yaml
@@ -7,8 +7,14 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created
+  - state: Completed
+    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/08-assert.yaml
+++ b/test/e2e-kuttl/steps/08-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/08-assert.yaml
+++ b/test/e2e-kuttl/steps/08-assert.yaml
@@ -9,8 +9,6 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/08-assert.yaml
+++ b/test/e2e-kuttl/steps/08-assert.yaml
@@ -7,6 +7,10 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/09-assert.yaml
+++ b/test/e2e-kuttl/steps/09-assert.yaml
@@ -9,12 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
-    step: accepted
-  - state: Running
     step: creating
   - state: Running
     step: created
-  - state: Completed
-    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e-kuttl/steps/09-assert.yaml
+++ b/test/e2e-kuttl/steps/09-assert.yaml
@@ -9,6 +9,8 @@ status:
   - state: Running
     step: dispatching
   - state: Running
+    step: accepting
+  - state: Running
     step: creating
   - state: Running
     step: created

--- a/test/e2e-kuttl/steps/09-assert.yaml
+++ b/test/e2e-kuttl/steps/09-assert.yaml
@@ -7,8 +7,14 @@ status:
   transitions:
   - state: Pending
   - state: Running
+    step: dispatching
+  - state: Running
+    step: accepted
+  - state: Running
     step: creating
   - state: Running
     step: created
+  - state: Completed
+    step: returned
   - state: Completed
   state: Completed

--- a/test/e2e/queue_test.go
+++ b/test/e2e/queue_test.go
@@ -157,7 +157,7 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 			By("Unready pods will trigger requeuing")
 			Eventually(AppWrapperQueuedReason(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(Equal(string(arbv1.QueuedRequeue)))
 			By("After reaching requeuing limit job is failed")
-			Eventually(AppWrapperState(ctx, aw.Namespace, aw.Name), 4*time.Minute).Should(Equal(arbv1.Failed))
+			Eventually(AppWrapperState(ctx, aw.Namespace, aw.Name), 5*time.Minute).Should(Equal(arbv1.Failed))
 		})
 
 		/*


### PR DESCRIPTION
Progress towards multi-cluster MCAD by splitting the AppWrapper reconciler into two separate reconcilers that handle disjoint state transitions in the lifecycle of the AppWrapper.
