### PR TITLE
increase deadline by 1 minute for requeueing test

### DIFF
--- a/test/e2e/queue_test.go
+++ b/test/e2e/queue_test.go
@@ -157,7 +157,7 @@ var _ = Describe("AppWrapper E2E Tests", func() {
 			By("Unready pods will trigger requeuing")
 			Eventually(AppWrapperQueuedReason(ctx, aw.Namespace, aw.Name), 2*time.Minute).Should(Equal(string(arbv1.QueuedRequeue)))
 			By("After reaching requeuing limit job is failed")
-			Eventually(AppWrapperState(ctx, aw.Namespace, aw.Name), 5*time.Minute).Should(Equal(arbv1.Failed))
+			Eventually(AppWrapperState(ctx, aw.Namespace, aw.Name), 6*time.Minute).Should(Equal(arbv1.Failed))
 		})
 
 		/*


### PR DESCRIPTION
give a little more slack to avoid spurious test failures (from the logs, the test had gotten to the next-to-last state and was almost done when the 5 minute timer expired).