### PR TITLE
multi-cluster: serialize status on dispatcher->runner

### DIFF
--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -48,7 +48,8 @@ type AppWrapperReconciler struct {
 const (
 	nameLabel            = "appwrapper.mcad.ibm.com"                     // owner name label for wrapped resources
 	namespaceLabel       = "appwrapper.mcad.ibm.com/namespace"           // owner namespace label for wrapped resources
-	assignedClusterLabel = "appwrapper.mcad.ibm.com/assignedCluster"     // cluster to which appwrapper has been assigned for execution.
+	assignedClusterLabel = "appwrapper.mcad.ibm.com/assignedCluster"     // cluster to which appwrapper has been assigned for execution
+	serializedStatusKey  = "appwrapper.mcad.ibm.com/serializedStatus"    // annotation key for serializing status from hub to spoke
 	dispatchFinalizer    = "workload.codeflare.dev/finalizer_dispatcher" // finalizer name for dispatcher
 	runnerFinalizer      = "workload.codeflare.dev/finalizer_runner"     // finalizer name for runner
 	nvidiaGpu            = "nvidia.com/gpu"                              // GPU resource name

--- a/internal/controller/dispatcher.go
+++ b/internal/controller/dispatcher.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -143,10 +144,20 @@ func (r *Dispatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		switch appWrapper.Status.Step {
 		case mcadv1beta1.Dispatching:
 			if r.MultiClusterMode {
+				// Serialize current status to an annotation so it can be mirrored in the execution cluster
+				pickledStatus, err := json.Marshal(appWrapper.Status)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				metav1.SetMetaDataAnnotation(&appWrapper.ObjectMeta, serializedStatusKey, string(pickledStatus))
+				if err := r.Update(ctx, appWrapper); err != nil {
+					return ctrl.Result{}, err
+				}
+
 				// TODO: Multicluster. This is where we create the placement that maps
 				// the appWrapper to the execution cluster. Only if the placement creation is successful
 				// will we do the update of the status to running/creating.
-				return ctrl.Result{}, fmt.Errorf("unimplemented multi-cluster synch path")
+				// return ctrl.Result{}, fmt.Errorf("unimplemented multi-cluster synch path")
 			}
 			return r.updateStatus(ctx, appWrapper, mcadv1beta1.Running, mcadv1beta1.Accepting)
 


### PR DESCRIPTION
Only the Spec is downsynched from the Hub cluster to the Spoke cluster by KubeStellar. To enable the Status to be preserved, implement custom serialization/deserialization of the status as part of the handoff from dispatcher to runner in multi-cluster mode.
